### PR TITLE
Imu improvements

### DIFF
--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -65,9 +65,9 @@ class IMU():
         self._scale_a_c = 1
         self._scale_g_c = 1
         self.acc_scale('16g')
-        self.gyro_scale('2000')
-        self.acc_rate('208')
-        self.gyro_rate('208')
+        self.gyro_scale('2000dps')
+        self.acc_rate('208Hz')
+        self.gyro_rate('208Hz')
 
         self.gyro_offsets = [0,0,0]
         self.acc_offsets = [0,0,0]
@@ -416,7 +416,7 @@ class IMU():
         else:
             # Set value as requested
             self.reg_ctrl2_g_struct.ODR_G = LSM_ODR[value]
-            self._setreg(LSM_REG_CTRL1_XL, self.reg_ctrl2_g_byte)
+            self._setreg(LSM_REG_CTRL2_G, self.reg_ctrl2_g_byte)
 
     def power(self, on:bool=None):
         """

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -49,6 +49,9 @@ class IMU():
         self.reg_ctrl2_g_bits    = struct(addressof(self.reg_ctrl2_g_byte), LSM_REG_LAYOUT_CTRL2_G)
         self.reg_ctrl3_c_bits    = struct(addressof(self.reg_ctrl3_c_byte), LSM_REG_LAYOUT_CTRL3_C)
 
+        # Create timer
+        self.update_timer = Timer(-1)
+
         # Check if the IMU is connected
         if not self.is_connected():
             # TODO - do somehting intelligent here
@@ -76,10 +79,6 @@ class IMU():
         self.running_pitch = 0
         self.running_yaw = 0
         self.running_roll = 0
-
-        # Create timer
-        self.update_timer = Timer(-1)
-
 
     """
         The following are private helper methods to read and write registers, as well as to convert the read values to the correct unit.

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -56,10 +56,10 @@ class IMU():
         self._power = True
         self._power_a = 0x10
         self._power_g = 0x10
-        # ODR_XL=1 FS_XL=0
-        self._setreg(LSM6DSO_CTRL1_XL, 0x10)
-        # ODR_G=1 FS_125=1
-        self._setreg(LSM6DSO_CTRL2_G, 0x12)
+        # Set accelerometer ODR=208Hz and FS=16g
+        self._setreg(LSM6DSO_CTRL1_XL, 0x54)
+        # Set gyroscope ODR=208Hz and FS=2000dps
+        self._setreg(LSM6DSO_CTRL2_G, 0x5C)
         # BDU=1 IF_INC=1
         self._setreg(LSM6DSO_CTRL3_C, 0x44)
         self._setreg(LSM6DSO_CTRL8_XL, 0)
@@ -74,7 +74,7 @@ class IMU():
         self.gyro_offsets = [0,0,0]
         self.acc_offsets = [0,0,0]
 
-        self.update_time = 0.004
+        self.update_time = 0.005
         self.gyro_pitch_bias = 0
         self.adjusted_pitch = 0
 
@@ -342,7 +342,7 @@ class IMU():
                 self._r_w_reg(LSM6DSO_CTRL1_XL, 0, 0x0F)
                 self._r_w_reg(LSM6DSO_CTRL2_G, 0, 0x0F)
 
-    def calibrate(self, calibration_time:float=1, vertical_axis:int= 2, update_time:int=4):
+    def calibrate(self, calibration_time:float=1, vertical_axis:int= 2, update_time:int=5):
         """
         Collect readings for [calibration_time] seconds and calibrate the IMU based on those readings
         Do not move the robot during this time

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -361,17 +361,29 @@ class IMU():
         self.gyro_offsets = [0,0,0]
         avg_vals = [[0,0,0],[0,0,0]]
         num_vals = 0
+        # Wait a bit for sensor to start measuring (data registers may default to something nonsensical)
+        time.sleep(.1)
         while time.ticks_ms() < start_time + calibration_time*1000:
             cur_vals = self._get_acc_gyro_rates()
             # Accelerometer averages
-            avg_vals[0][0] = (avg_vals[0][0]*num_vals+cur_vals[0][0])/(num_vals+1)
-            avg_vals[0][1] = (avg_vals[0][1]*num_vals+cur_vals[0][1])/(num_vals+1)
-            avg_vals[0][2] = (avg_vals[0][2]*num_vals+cur_vals[0][2])/(num_vals+1)
+            avg_vals[0][0] += cur_vals[0][0]
+            avg_vals[0][1] += cur_vals[0][1]
+            avg_vals[0][2] += cur_vals[0][2]
             # Gyroscope averages
-            avg_vals[1][0] = (avg_vals[1][0]*num_vals+cur_vals[1][0])/(num_vals+1)
-            avg_vals[1][1] = (avg_vals[1][1]*num_vals+cur_vals[1][1])/(num_vals+1)
-            avg_vals[1][2] = (avg_vals[1][2]*num_vals+cur_vals[1][2])/(num_vals+1)
-            time.sleep(0.05)
+            avg_vals[1][0] += cur_vals[1][0]
+            avg_vals[1][1] += cur_vals[1][1]
+            avg_vals[1][2] += cur_vals[1][2]
+            # Increment counter and wait for next loop
+            num_vals += 1
+            time.sleep(update_time / 1000)
+
+        # Compute averages
+        avg_vals[0][0] /= num_vals
+        avg_vals[0][1] /= num_vals
+        avg_vals[0][2] /= num_vals
+        avg_vals[1][0] /= num_vals
+        avg_vals[1][1] /= num_vals
+        avg_vals[1][2] /= num_vals
 
         avg_vals[0][vertical_axis] -= 1000 #in mg
 

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -40,11 +40,6 @@ class IMU():
         # Vector of IMU measurements
         self.irq_v = [[0, 0, 0], [0, 0, 0]]
 
-        # Power control
-        self._power = True
-        self._power_a = 0x10
-        self._power_g = 0x10
-        
         # Copies of registers. Bytes and structs share the same memory
         # addresses, so changing one changes the other
         self.reg_ctrl1_xl_byte   = bytearray(1)
@@ -422,27 +417,6 @@ class IMU():
             # Update timer frequency
             self.timer_frequency = int(value.rstrip('Hz'))
             self._start_timer()
-
-    def power(self, on:bool=None):
-        """
-        Turn the LSM6DSO on or off.
-        Pass in no parameters to retrieve the current value
-
-        :param on: Whether to turn the LSM6DSO on or off, or None
-        :type on: bool (or None)
-        """
-        if on is None:
-            return self._power
-        else:
-            self._power = on
-            if on:
-                self._r_w_reg(LSM_REG_CTRL1_XL, self._power_a, 0x0F)
-                self._r_w_reg(LSM_REG_CTRL2_G, self._power_g, 0x0F)
-            else:
-                self._power_a = self._getreg(LSM_REG_CTRL1_XL) & 0xF0
-                self._power_g = self._getreg(LSM_REG_CTRL2_G) & 0xF0
-                self._r_w_reg(LSM_REG_CTRL1_XL, 0, 0x0F)
-                self._r_w_reg(LSM_REG_CTRL2_G, 0, 0x0F)
 
     def calibrate(self, calibration_time:float=1, vertical_axis:int= 2):
         """

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -112,47 +112,6 @@ class IMU():
         self.rb[0] = (self.rb[0] & mask) | dat
         self._setreg(reg, self.rb[0])
 
-    def is_connected(self):
-        """
-        Checks whether the IMU is connected
-
-        :return: True if WHO_AM_I value is correct, otherwise False
-        :rtype: bool
-        """
-        who_am_i = self._getreg(LSM_REG_WHO_AM_I)
-        return who_am_i == 0x6C
-
-    def reset(self, wait_for_reset = True, wait_timeout_ms = 100):
-        """
-        Resets the IMU, and restores all registers to their default values
-
-        :param wait_for_reset: Whether to wait for reset to complete
-        :type wait_for_reset: bool
-        :param wait_timeout_ms: Timeout in milliseconds when waiting for reset
-        :type wait_timeout_ms: int
-        :return: False if timeout occurred, otherwise True
-        :rtype: bool
-        """
-        # Set BOOT and SW_RESET bits
-        self.reg_ctrl3_c_byte[0] = self._getreg(LSM_REG_CTRL3_C)
-        self.reg_ctrl3_c_bits.BOOT = 1
-        self.reg_ctrl3_c_bits.SW_RESET = 1
-        self._setreg(LSM_REG_CTRL3_C, self.reg_ctrl3_c_byte[0])
-
-        # Wait for reset to complete, if requested
-        if wait_for_reset:
-            # Loop with timeout
-            t0 = time.ticks_ms()
-            while time.ticks_ms() < (t0 + wait_timeout_ms):
-                # Check if register has returned to default value (0x04)
-                self.reg_ctrl3_c_byte[0] = self._getreg(LSM_REG_CTRL3_C)
-                if self.reg_ctrl3_c_byte[0] == 0x04:
-                    return True
-            # Timeout occurred
-            return False
-        else:
-            return True
-
     def _set_bdu(self, bdu = True):
         """
         Sets Block Data Update bit
@@ -242,6 +201,47 @@ class IMU():
     """
         Public facing API Methods
     """
+
+    def is_connected(self):
+        """
+        Checks whether the IMU is connected
+
+        :return: True if WHO_AM_I value is correct, otherwise False
+        :rtype: bool
+        """
+        who_am_i = self._getreg(LSM_REG_WHO_AM_I)
+        return who_am_i == 0x6C
+
+    def reset(self, wait_for_reset = True, wait_timeout_ms = 100):
+        """
+        Resets the IMU, and restores all registers to their default values
+
+        :param wait_for_reset: Whether to wait for reset to complete
+        :type wait_for_reset: bool
+        :param wait_timeout_ms: Timeout in milliseconds when waiting for reset
+        :type wait_timeout_ms: int
+        :return: False if timeout occurred, otherwise True
+        :rtype: bool
+        """
+        # Set BOOT and SW_RESET bits
+        self.reg_ctrl3_c_byte[0] = self._getreg(LSM_REG_CTRL3_C)
+        self.reg_ctrl3_c_bits.BOOT = 1
+        self.reg_ctrl3_c_bits.SW_RESET = 1
+        self._setreg(LSM_REG_CTRL3_C, self.reg_ctrl3_c_byte[0])
+
+        # Wait for reset to complete, if requested
+        if wait_for_reset:
+            # Loop with timeout
+            t0 = time.ticks_ms()
+            while time.ticks_ms() < (t0 + wait_timeout_ms):
+                # Check if register has returned to default value (0x04)
+                self.reg_ctrl3_c_byte[0] = self._getreg(LSM_REG_CTRL3_C)
+                if self.reg_ctrl3_c_byte[0] == 0x04:
+                    return True
+            # Timeout occurred
+            return False
+        else:
+            return True
 
     def get_acc_x(self):
         """

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -137,70 +137,6 @@ class IMU():
 
     def _raw_to_mdps(self, raw):
         return self._int16((raw[1] << 8) | raw[0]) * LSM_MDPS_PER_LSB_125DPS * self._gyro_scale_factor
-
-    def _get_gyro_x_rate(self):
-        """
-            Individual axis read for the Gyroscope's X-axis, in mg
-        """
-        # Burst read data registers
-        raw_bytes = self._getregs(LSM_REG_OUTX_L_G, 2)
-
-        # Convert raw data to mdps
-        return self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[0]
-
-    def _get_gyro_y_rate(self):
-        """
-            Individual axis read for the Gyroscope's Y-axis, in mg
-        """
-        # Burst read data registers
-        raw_bytes = self._getregs(LSM_REG_OUTY_L_G, 2)
-
-        # Convert raw data to mdps
-        return self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[1]
-
-    def _get_gyro_z_rate(self):
-        """
-            Individual axis read for the Gyroscope's Z-axis, in mg
-        """
-        # Burst read data registers
-        raw_bytes = self._getregs(LSM_REG_OUTZ_L_G, 2)
-
-        # Convert raw data to mdps
-        return self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[2]
-
-    def _get_gyro_rates(self):
-        """
-            Retrieves the array of readings from the Gyroscope, in mdps
-            The order of the values is x, y, z.
-        """
-        # Burst read data registers
-        raw_bytes = self._getregs(LSM_REG_OUTX_L_G, 6)
-
-        # Convert raw data to mdps
-        self.irq_v[1][0] = self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[0]
-        self.irq_v[1][1] = self._raw_to_mdps(raw_bytes[2:4]) - self.gyro_offsets[1]
-        self.irq_v[1][2] = self._raw_to_mdps(raw_bytes[4:6]) - self.gyro_offsets[2]
-
-        return self.irq_v[1]
-
-    def _get_acc_gyro_rates(self):
-        """
-            Get the accelerometer and gyroscope values in mg and mdps in the form of a 2D array.
-            The first row is the acceleration values, the second row is the gyro values.
-            The order of the values is x, y, z.
-        """
-        # Burst read data registers
-        raw_bytes = self._getregs(LSM_REG_OUTX_L_G, 12)
-
-        # Convert raw data to mg's and mdps
-        self.irq_v[0][0] = self._raw_to_mg(raw_bytes[6:8]) - self.acc_offsets[0]
-        self.irq_v[0][1] = self._raw_to_mg(raw_bytes[8:10]) - self.acc_offsets[1]
-        self.irq_v[0][2] = self._raw_to_mg(raw_bytes[10:12]) - self.acc_offsets[2]
-        self.irq_v[1][0] = self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[0]
-        self.irq_v[1][1] = self._raw_to_mdps(raw_bytes[2:4]) - self.gyro_offsets[1]
-        self.irq_v[1][2] = self._raw_to_mdps(raw_bytes[4:6]) - self.gyro_offsets[2]
-
-        return self.irq_v
     
     """
         Public facing API Methods
@@ -300,6 +236,70 @@ class IMU():
         self.irq_v[0][2] = self._raw_to_mg(raw_bytes[4:6]) - self.acc_offsets[2]
 
         return self.irq_v[0]
+
+    def get_gyro_x_rate(self):
+        """
+            Individual axis read for the Gyroscope's X-axis, in mg
+        """
+        # Burst read data registers
+        raw_bytes = self._getregs(LSM_REG_OUTX_L_G, 2)
+
+        # Convert raw data to mdps
+        return self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[0]
+
+    def get_gyro_y_rate(self):
+        """
+            Individual axis read for the Gyroscope's Y-axis, in mg
+        """
+        # Burst read data registers
+        raw_bytes = self._getregs(LSM_REG_OUTY_L_G, 2)
+
+        # Convert raw data to mdps
+        return self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[1]
+
+    def get_gyro_z_rate(self):
+        """
+            Individual axis read for the Gyroscope's Z-axis, in mg
+        """
+        # Burst read data registers
+        raw_bytes = self._getregs(LSM_REG_OUTZ_L_G, 2)
+
+        # Convert raw data to mdps
+        return self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[2]
+
+    def get_gyro_rates(self):
+        """
+            Retrieves the array of readings from the Gyroscope, in mdps
+            The order of the values is x, y, z.
+        """
+        # Burst read data registers
+        raw_bytes = self._getregs(LSM_REG_OUTX_L_G, 6)
+
+        # Convert raw data to mdps
+        self.irq_v[1][0] = self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[0]
+        self.irq_v[1][1] = self._raw_to_mdps(raw_bytes[2:4]) - self.gyro_offsets[1]
+        self.irq_v[1][2] = self._raw_to_mdps(raw_bytes[4:6]) - self.gyro_offsets[2]
+
+        return self.irq_v[1]
+
+    def get_acc_gyro_rates(self):
+        """
+            Get the accelerometer and gyroscope values in mg and mdps in the form of a 2D array.
+            The first row is the acceleration values, the second row is the gyro values.
+            The order of the values is x, y, z.
+        """
+        # Burst read data registers
+        raw_bytes = self._getregs(LSM_REG_OUTX_L_G, 12)
+
+        # Convert raw data to mg's and mdps
+        self.irq_v[0][0] = self._raw_to_mg(raw_bytes[6:8]) - self.acc_offsets[0]
+        self.irq_v[0][1] = self._raw_to_mg(raw_bytes[8:10]) - self.acc_offsets[1]
+        self.irq_v[0][2] = self._raw_to_mg(raw_bytes[10:12]) - self.acc_offsets[2]
+        self.irq_v[1][0] = self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[0]
+        self.irq_v[1][1] = self._raw_to_mdps(raw_bytes[2:4]) - self.gyro_offsets[1]
+        self.irq_v[1][2] = self._raw_to_mdps(raw_bytes[4:6]) - self.gyro_offsets[2]
+
+        return self.irq_v
     
     def get_pitch(self):
         """
@@ -503,7 +503,7 @@ class IMU():
         time.sleep(.1)
         start_time = time.ticks_ms()
         while time.ticks_ms() < start_time + calibration_time*1000:
-            cur_vals = self._get_acc_gyro_rates()
+            cur_vals = self.get_acc_gyro_rates()
             # Accelerometer averages
             avg_vals[0][0] += cur_vals[0][0]
             avg_vals[0][1] += cur_vals[0][1]
@@ -538,7 +538,7 @@ class IMU():
 
     def _update_imu_readings(self):
         # Called every tick through a callback timer
-        self._get_gyro_rates()
+        self.get_gyro_rates()
         delta_pitch = self.irq_v[1][0] / 1000 / self.timer_frequency
         delta_roll = self.irq_v[1][1] / 1000 / self.timer_frequency
         delta_yaw = self.irq_v[1][2] / 1000 / self.timer_frequency

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -248,7 +248,7 @@ class IMU():
         raw_bytes = self._getregs(LSM_REG_OUTX_L_A, 2)
 
         # Convert raw data to mg's
-        return self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[0]
+        return self._raw_to_mg(raw_bytes[0:2]) - self.acc_offsets[0]
 
     def get_acc_y(self):
         """
@@ -259,7 +259,7 @@ class IMU():
         raw_bytes = self._getregs(LSM_REG_OUTY_L_A, 2)
 
         # Convert raw data to mg's
-        return self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[1]
+        return self._raw_to_mg(raw_bytes[0:2]) - self.acc_offsets[1]
 
     def get_acc_z(self):
         """
@@ -270,7 +270,7 @@ class IMU():
         raw_bytes = self._getregs(LSM_REG_OUTZ_L_A, 2)
 
         # Convert raw data to mg's
-        return self._raw_to_mdps(raw_bytes[0:2]) - self.gyro_offsets[2]
+        return self._raw_to_mg(raw_bytes[0:2]) - self.acc_offsets[2]
     
     def get_acc_rates(self):
         """

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -45,9 +45,9 @@ class IMU():
         self.reg_ctrl1_xl_byte   = bytearray(1)
         self.reg_ctrl2_g_byte    = bytearray(1)
         self.reg_ctrl3_c_byte    = bytearray(1)
-        self.reg_ctrl1_xl_struct = struct(addressof(self.reg_ctrl1_xl_byte), LSM_REG_LAYOUT_CTRL1_XL)
-        self.reg_ctrl2_g_struct  = struct(addressof(self.reg_ctrl2_g_byte), LSM_REG_LAYOUT_CTRL2_G)
-        self.reg_ctrl3_c_struct  = struct(addressof(self.reg_ctrl3_c_byte), LSM_REG_LAYOUT_CTRL3_C)
+        self.reg_ctrl1_xl_bits   = struct(addressof(self.reg_ctrl1_xl_byte), LSM_REG_LAYOUT_CTRL1_XL)
+        self.reg_ctrl2_g_bits    = struct(addressof(self.reg_ctrl2_g_byte), LSM_REG_LAYOUT_CTRL2_G)
+        self.reg_ctrl3_c_bits    = struct(addressof(self.reg_ctrl3_c_byte), LSM_REG_LAYOUT_CTRL3_C)
 
         # Check if the IMU is connected
         if not self.is_connected():
@@ -127,8 +127,8 @@ class IMU():
         """
         # Set BOOT and SW_RESET bits
         self.reg_ctrl3_c_byte = self._getreg(LSM_REG_CTRL3_C)
-        self.reg_ctrl3_c_struct.BOOT = 1
-        self.reg_ctrl3_c_struct.SW_RESET = 1
+        self.reg_ctrl3_c_bits.BOOT = 1
+        self.reg_ctrl3_c_bits.SW_RESET = 1
         self._setreg(LSM_REG_CTRL3_C, self.reg_ctrl3_c_byte)
 
         # Wait for reset to complete, if requested
@@ -150,7 +150,7 @@ class IMU():
         Sets Block Data Update bit
         """
         self.reg_ctrl3_c_byte = self._getreg(LSM_REG_CTRL3_C)
-        self.reg_ctrl3_c_struct.BDU = bdu
+        self.reg_ctrl3_c_bits.BDU = bdu
         self._setreg(LSM_REG_CTRL3_C, self.reg_ctrl3_c_byte)
 
     def _set_if_inc(self, if_inc = True):
@@ -158,7 +158,7 @@ class IMU():
         Sets InterFace INCrement bit
         """
         self.reg_ctrl3_c_byte = self._getreg(LSM_REG_CTRL3_C)
-        self.reg_ctrl3_c_struct.IF_INC = if_inc
+        self.reg_ctrl3_c_bits.IF_INC = if_inc
         self._setreg(LSM_REG_CTRL3_C, self.reg_ctrl3_c_byte)
 
     def _mg(self, reg):
@@ -353,11 +353,11 @@ class IMU():
         #  Check if the provided value is in the dictionary
         if value not in LSM_ACCEL_FS:
             # Return string representation of this value
-            index = list(LSM_ACCEL_FS.values()).index(self.reg_ctrl1_xl_struct.FS_XL)
+            index = list(LSM_ACCEL_FS.values()).index(self.reg_ctrl1_xl_bits.FS_XL)
             return list(LSM_ACCEL_FS.keys())[index]
         else:
             # Set value as requested
-            self.reg_ctrl1_xl_struct.FS_XL = LSM_ACCEL_FS[value]
+            self.reg_ctrl1_xl_bits.FS_XL = LSM_ACCEL_FS[value]
             self._setreg(LSM_REG_CTRL1_XL, self.reg_ctrl1_xl_byte)
 
     def gyro_scale(self, value=None):
@@ -371,11 +371,11 @@ class IMU():
         #  Check if the provided value is in the dictionary
         if value not in LSM_GYRO_FS:
             # Return string representation of this value
-            index = list(LSM_GYRO_FS.values()).index(self.reg_ctrl2_g_struct.FS_G)
+            index = list(LSM_GYRO_FS.values()).index(self.reg_ctrl2_g_bits.FS_G)
             return list(LSM_GYRO_FS.keys())[index]
         else:
             # Set value as requested
-            self.reg_ctrl2_g_struct.FS_G = LSM_GYRO_FS[value]
+            self.reg_ctrl2_g_bits.FS_G = LSM_GYRO_FS[value]
             self._setreg(LSM_REG_CTRL2_G, self.reg_ctrl2_g_byte)
 
     def acc_rate(self, value=None):
@@ -389,11 +389,11 @@ class IMU():
         #  Check if the provided value is in the dictionary
         if value not in LSM_ODR:
             # Return string representation of this value
-            index = list(LSM_ODR.values()).index(self.reg_ctrl1_xl_struct.ODR_XL)
+            index = list(LSM_ODR.values()).index(self.reg_ctrl1_xl_bits.ODR_XL)
             return list(LSM_ODR.keys())[index]
         else:
             # Set value as requested
-            self.reg_ctrl1_xl_struct.ODR_XL = LSM_ODR[value]
+            self.reg_ctrl1_xl_bits.ODR_XL = LSM_ODR[value]
             self._setreg(LSM_REG_CTRL1_XL, self.reg_ctrl1_xl_byte)
 
     def gyro_rate(self, value=None):
@@ -407,11 +407,11 @@ class IMU():
         #  Check if the provided value is in the dictionary
         if value not in LSM_ODR:
             # Return string representation of this value
-            index = list(LSM_ODR.values()).index(self.reg_ctrl1_xl_struct.ODR_G)
+            index = list(LSM_ODR.values()).index(self.reg_ctrl1_xl_bits.ODR_G)
             return list(LSM_ODR.keys())[index]
         else:
             # Set value as requested
-            self.reg_ctrl2_g_struct.ODR_G = LSM_ODR[value]
+            self.reg_ctrl2_g_bits.ODR_G = LSM_ODR[value]
             self._setreg(LSM_REG_CTRL2_G, self.reg_ctrl2_g_byte)
 
             # Update timer frequency

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -399,13 +399,13 @@ class IMU():
         :type update_time: int
         """
         self.update_timer.deinit()
-        start_time = time.ticks_ms()
         self.acc_offsets = [0,0,0]
         self.gyro_offsets = [0,0,0]
         avg_vals = [[0,0,0],[0,0,0]]
         num_vals = 0
         # Wait a bit for sensor to start measuring (data registers may default to something nonsensical)
         time.sleep(.1)
+        start_time = time.ticks_ms()
         while time.ticks_ms() < start_time + calibration_time*1000:
             cur_vals = self._get_acc_gyro_rates()
             # Accelerometer averages

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -27,6 +27,8 @@ LSM6DSO_OUTZ_L_A = 0x2C
 """
 LSM6DSO_SCALEA = ('2g', '16g', '4g', '8g')
 LSM6DSO_SCALEG = ('250', '125', '500', '', '1000', '', '2000')
+LSM6DSO_ODRA = ('0', '12.5', '26', '52', '104', '208', '416', '833', '1660', '3330', '6660')
+LSM6DSO_ODRG = ('0', '12.5', '26', '52', '104', '208', '416', '833', '1660', '3330', '6660')
 
 class IMU():
 
@@ -75,10 +77,6 @@ class IMU():
             if (foo == 0x04) or (time.ticks_ms() > (t0 + timeout_ms)):
                 break
         
-        # Set accelerometer ODR=208Hz and FS=16g
-        self._setreg(LSM6DSO_CTRL1_XL, 0x54)
-        # Set gyroscope ODR=208Hz and FS=2000dps
-        self._setreg(LSM6DSO_CTRL2_G, 0x5C)
         # BDU=1 IF_INC=1
         self._setreg(LSM6DSO_CTRL3_C, 0x44)
         self._setreg(LSM6DSO_CTRL8_XL, 0)
@@ -89,6 +87,8 @@ class IMU():
         self._scale_g_c = 1
         self.acc_scale('16g')
         self.gyro_scale('2000')
+        self.acc_rate('208')
+        self.gyro_rate('208')
 
         self.gyro_offsets = [0,0,0]
         self.acc_offsets = [0,0,0]
@@ -339,6 +339,30 @@ class IMU():
                 self._scale_g_c = int(dat)//125
             else: return
             self._r_w_reg(LSM6DSO_CTRL2_G, self._scale_g<<1, 0xF1)
+
+    def acc_rate(self, dat=None):
+        """
+        Set the accelerometer rate. The rate can be '0', '12.5', '26', '52', '104', '208', '416', '833', '1660', '3330', '6660'.
+        Pass in no parameters to retrieve the current value
+        """
+        if (dat is None) or (type(dat) is not str) or (dat not in LSM6DSO_ODRA):
+            reg_val = self._getreg(LSM6DSO_CTRL1_XL)
+            return (reg_val >> 4) & 0x04
+        else:
+            reg_val = LSM6DSO_ODRA.index(dat) << 4
+            return self._r_w_reg(LSM6DSO_CTRL1_XL, reg_val, 0xF0)
+
+    def gyro_rate(self, dat=None):
+        """
+        Set the gyroscope rate. The rate can be '0', '12.5', '26', '52', '104', '208', '416', '833', '1660', '3330', '6660'.
+        Pass in no parameters to retrieve the current value
+        """
+        if (dat is None) or (type(dat) is not str) or (dat not in LSM6DSO_ODRG):
+            reg_val = self._getreg(LSM6DSO_CTRL2_G)
+            return (reg_val >> 4) & 0x04
+        else:
+            reg_val = LSM6DSO_ODRG.index(dat) << 4
+            return self._r_w_reg(LSM6DSO_CTRL2_G, reg_val, 0xF0)
 
     def power(self, on:bool=None):
         """

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -350,7 +350,7 @@ class IMU():
             return (reg_val >> 4) & 0x04
         else:
             reg_val = LSM6DSO_ODRA.index(dat) << 4
-            return self._r_w_reg(LSM6DSO_CTRL1_XL, reg_val, 0xF0)
+            return self._r_w_reg(LSM6DSO_CTRL1_XL, reg_val, 0x0F)
 
     def gyro_rate(self, dat=None):
         """
@@ -362,7 +362,7 @@ class IMU():
             return (reg_val >> 4) & 0x04
         else:
             reg_val = LSM6DSO_ODRG.index(dat) << 4
-            return self._r_w_reg(LSM6DSO_CTRL2_G, reg_val, 0xF0)
+            return self._r_w_reg(LSM6DSO_CTRL2_G, reg_val, 0x0F)
 
     def power(self, on:bool=None):
         """

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -150,7 +150,7 @@ class IMU():
         :rtype: bool
         """
         who_am_i = self._getreg(LSM_REG_WHO_AM_I)
-        return who_am_i == 0x6C
+        return who_am_i == LSM_WHO_AM_I_VALUE
 
     def reset(self, wait_for_reset = True, wait_timeout_ms = 100):
         """

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -130,10 +130,10 @@ class IMU():
         :rtype: bool
         """
         # Set BOOT and SW_RESET bits
-        self.reg_ctrl3_c_byte = self._getreg(LSM_REG_CTRL3_C)
+        self.reg_ctrl3_c_byte[0] = self._getreg(LSM_REG_CTRL3_C)
         self.reg_ctrl3_c_bits.BOOT = 1
         self.reg_ctrl3_c_bits.SW_RESET = 1
-        self._setreg(LSM_REG_CTRL3_C, self.reg_ctrl3_c_byte)
+        self._setreg(LSM_REG_CTRL3_C, self.reg_ctrl3_c_byte[0])
 
         # Wait for reset to complete, if requested
         if wait_for_reset:
@@ -141,8 +141,8 @@ class IMU():
             t0 = time.ticks_ms()
             while time.ticks_ms() < (t0 + wait_timeout_ms):
                 # Check if register has returned to default value (0x04)
-                self.reg_ctrl3_c_byte = self._getreg(LSM_REG_CTRL3_C)
-                if self.reg_ctrl3_c_byte == 0x04:
+                self.reg_ctrl3_c_byte[0] = self._getreg(LSM_REG_CTRL3_C)
+                if self.reg_ctrl3_c_byte[0] == 0x04:
                     return True
             # Timeout occurred
             return False
@@ -153,17 +153,17 @@ class IMU():
         """
         Sets Block Data Update bit
         """
-        self.reg_ctrl3_c_byte = self._getreg(LSM_REG_CTRL3_C)
+        self.reg_ctrl3_c_byte[0] = self._getreg(LSM_REG_CTRL3_C)
         self.reg_ctrl3_c_bits.BDU = bdu
-        self._setreg(LSM_REG_CTRL3_C, self.reg_ctrl3_c_byte)
+        self._setreg(LSM_REG_CTRL3_C, self.reg_ctrl3_c_byte[0])
 
     def _set_if_inc(self, if_inc = True):
         """
         Sets InterFace INCrement bit
         """
-        self.reg_ctrl3_c_byte = self._getreg(LSM_REG_CTRL3_C)
+        self.reg_ctrl3_c_byte[0] = self._getreg(LSM_REG_CTRL3_C)
         self.reg_ctrl3_c_bits.IF_INC = if_inc
-        self._setreg(LSM_REG_CTRL3_C, self.reg_ctrl3_c_byte)
+        self._setreg(LSM_REG_CTRL3_C, self.reg_ctrl3_c_byte[0])
 
     def _raw_to_mg(self, raw):
         return self._int16((raw[1] << 8) | raw[0]) * LSM_MG_PER_LSB
@@ -396,7 +396,7 @@ class IMU():
         Pass in no parameters to retrieve the current value
         """
         # Get register value
-        self.reg_ctrl1_xl_byte = self._getreg(LSM_REG_CTRL1_XL)
+        self.reg_ctrl1_xl_byte[0] = self._getreg(LSM_REG_CTRL1_XL)
         #  Check if the provided value is in the dictionary
         if value not in LSM_ACCEL_FS:
             # Return string representation of this value
@@ -405,7 +405,7 @@ class IMU():
         else:
             # Set value as requested
             self.reg_ctrl1_xl_bits.FS_XL = LSM_ACCEL_FS[value]
-            self._setreg(LSM_REG_CTRL1_XL, self.reg_ctrl1_xl_byte)
+            self._setreg(LSM_REG_CTRL1_XL, self.reg_ctrl1_xl_byte[0])
 
     def gyro_scale(self, value=None):
         """
@@ -414,7 +414,7 @@ class IMU():
         Pass in no parameters to retrieve the current value
         """
         # Get register value
-        self.reg_ctrl2_g_byte = self._getreg(LSM_REG_CTRL2_G)
+        self.reg_ctrl2_g_byte[0] = self._getreg(LSM_REG_CTRL2_G)
         #  Check if the provided value is in the dictionary
         if value not in LSM_GYRO_FS:
             # Return string representation of this value
@@ -423,7 +423,7 @@ class IMU():
         else:
             # Set value as requested
             self.reg_ctrl2_g_bits.FS_G = LSM_GYRO_FS[value]
-            self._setreg(LSM_REG_CTRL2_G, self.reg_ctrl2_g_byte)
+            self._setreg(LSM_REG_CTRL2_G, self.reg_ctrl2_g_byte[0])
 
     def acc_rate(self, value=None):
         """
@@ -432,7 +432,7 @@ class IMU():
         Pass in no parameters to retrieve the current value
         """
         # Get register value
-        self.reg_ctrl1_xl_byte = self._getreg(LSM_REG_CTRL1_XL)
+        self.reg_ctrl1_xl_byte[0] = self._getreg(LSM_REG_CTRL1_XL)
         #  Check if the provided value is in the dictionary
         if value not in LSM_ODR:
             # Return string representation of this value
@@ -441,7 +441,7 @@ class IMU():
         else:
             # Set value as requested
             self.reg_ctrl1_xl_bits.ODR_XL = LSM_ODR[value]
-            self._setreg(LSM_REG_CTRL1_XL, self.reg_ctrl1_xl_byte)
+            self._setreg(LSM_REG_CTRL1_XL, self.reg_ctrl1_xl_byte[0])
 
     def gyro_rate(self, value=None):
         """
@@ -450,7 +450,7 @@ class IMU():
         Pass in no parameters to retrieve the current value
         """
         # Get register value
-        self.reg_ctrl2_g_byte = self._getreg(LSM_REG_CTRL2_G)
+        self.reg_ctrl2_g_byte[0] = self._getreg(LSM_REG_CTRL2_G)
         #  Check if the provided value is in the dictionary
         if value not in LSM_ODR:
             # Return string representation of this value
@@ -459,7 +459,7 @@ class IMU():
         else:
             # Set value as requested
             self.reg_ctrl2_g_bits.ODR_G = LSM_ODR[value]
-            self._setreg(LSM_REG_CTRL2_G, self.reg_ctrl2_g_byte)
+            self._setreg(LSM_REG_CTRL2_G, self.reg_ctrl2_g_byte[0])
 
             # Update timer frequency
             self.timer_frequency = int(value.rstrip('Hz'))

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -87,8 +87,8 @@ class IMU():
         self._scale_g = 0
         self._scale_a_c = 1
         self._scale_g_c = 1
-        self.acc_scale('2g')
-        self.gyro_scale('500')
+        self.acc_scale('16g')
+        self.gyro_scale('2000')
 
         self.gyro_offsets = [0,0,0]
         self.acc_offsets = [0,0,0]

--- a/XRPLib/imu_defs.py
+++ b/XRPLib/imu_defs.py
@@ -74,3 +74,9 @@ LSM_GYRO_FS = {
 	"1000dps" : 0x4,
 	"2000dps" : 0x6,
 }
+
+"""
+    Other contants
+"""
+LSM_MG_PER_LSB   = 0.061
+LSM_MDPS_PER_LSB = 4.375

--- a/XRPLib/imu_defs.py
+++ b/XRPLib/imu_defs.py
@@ -78,5 +78,5 @@ LSM_GYRO_FS = {
 """
     Other contants
 """
-LSM_MG_PER_LSB   = 0.061
-LSM_MDPS_PER_LSB = 4.375
+LSM_MG_PER_LSB_2G       = 0.061
+LSM_MDPS_PER_LSB_125DPS = 4.375

--- a/XRPLib/imu_defs.py
+++ b/XRPLib/imu_defs.py
@@ -1,0 +1,76 @@
+from uctypes import BFUINT8, BF_POS, BF_LEN
+from micropython import const
+
+"""
+	Possible I2C addresses
+"""
+LSM_ADDR_PRIMARY   = const(0x6B)
+LSM_ADDR_SECONDARY = const(0x6A)
+
+"""
+	Register addresses
+"""
+LSM_REG_WHO_AM_I         = const(0x0F)
+LSM_REG_CTRL1_XL         = const(0x10)
+LSM_REG_CTRL2_G          = const(0x11)
+LSM_REG_CTRL3_C          = const(0x12)
+LSM_REG_OUT_TEMP_L       = const(0x20)
+LSM_REG_OUT_TEMP_H       = const(0x21)
+LSM_REG_OUTX_L_G         = const(0x22)
+LSM_REG_OUTY_L_G         = const(0x24)
+LSM_REG_OUTZ_L_G         = const(0x26)
+LSM_REG_OUTX_L_A         = const(0x28)
+LSM_REG_OUTY_L_A         = const(0x2A)
+LSM_REG_OUTZ_L_A         = const(0x2C)
+
+"""
+	Bit field struct definitions of registers
+"""
+LSM_REG_LAYOUT_CTRL1_XL = {
+    "ODR_XL"     : BFUINT8 | 4 << BF_POS | 4 << BF_LEN,
+    "FS_XL"      : BFUINT8 | 2 << BF_POS | 2 << BF_LEN,
+    "LPF2_XL_EN" : BFUINT8 | 1 << BF_POS | 1 << BF_LEN,
+}
+LSM_REG_LAYOUT_CTRL2_G = {
+    "ODR_G" : BFUINT8 | 4 << BF_POS | 4 << BF_LEN,
+    "FS_G"  : BFUINT8 | 1 << BF_POS | 3 << BF_LEN,
+}
+LSM_REG_LAYOUT_CTRL3_C = {
+    "BOOT"      : BFUINT8 | 7 << BF_POS | 1 << BF_LEN,
+    "BDU"       : BFUINT8 | 6 << BF_POS | 1 << BF_LEN,
+    "H_LACTIVE" : BFUINT8 | 5 << BF_POS | 1 << BF_LEN,
+    "PP_OD"     : BFUINT8 | 4 << BF_POS | 1 << BF_LEN,
+    "SIM"       : BFUINT8 | 3 << BF_POS | 1 << BF_LEN,
+    "IF_INC"    : BFUINT8 | 2 << BF_POS | 1 << BF_LEN,
+    "SW_RESET"  : BFUINT8 | 0 << BF_POS | 1 << BF_LEN,
+}
+
+"""
+	Dictionaries for possible register settings
+"""
+LSM_ODR = {
+	"0Hz"    : 0x0,
+	"12.5Hz" : 0x1,
+	"26Hz"   : 0x2,
+	"52Hz"   : 0x3,
+	"104Hz"  : 0x4,
+	"208Hz"  : 0x5,
+	"416Hz"  : 0x6,
+	"833Hz"  : 0x7,
+	"1660Hz" : 0x8,
+	"3330Hz" : 0x9,
+	"6660Hz" : 0xA,
+}
+LSM_ACCEL_FS = {
+	"2g"  : 0x0,
+	"4g"  : 0x2,
+	"8g"  : 0x3,
+	"16g" : 0x1,
+}
+LSM_GYRO_FS = {
+	"125dps"  : 0x1,
+	"250dps"  : 0x0,
+	"500dps"  : 0x2,
+	"1000dps" : 0x4,
+	"2000dps" : 0x6,
+}

--- a/XRPLib/imu_defs.py
+++ b/XRPLib/imu_defs.py
@@ -78,5 +78,6 @@ LSM_GYRO_FS = {
 """
     Other contants
 """
+LSM_WHO_AM_I_VALUE      = 0x6C
 LSM_MG_PER_LSB_2G       = 0.061
 LSM_MDPS_PER_LSB_125DPS = 4.375


### PR DESCRIPTION
A handful of general improvements to the IMU class. Notable changes include:
* Fix IMU calibration loop to actually get an average for the offset, rather than just the last measurement (`num_vals` was never incremented)
* Optimize IMU calibration to only divide once after measurement loop (division takes a long time)
* Add ODR functions
* Change default ODR to 208Hz, and default update period to 5ms (close as possible to 208Hz)
* Change default FS ranges to max (not clipping is more important than fine resolution, but feel free to change if max is too much)
* Check WHO_AM_I register during initialization (still need to implement something intelligent if it fails)
* Reset IMU during initialization (clears any previous configuration in case the processor is reset without power cycling the IMU)