### PR TITLE
Remove IMU call from resetbot.py

### DIFF
--- a/XRPLib/resetbot.py
+++ b/XRPLib/resetbot.py
@@ -14,9 +14,6 @@ for i in range(4):
     motor.set_effort(0)
     motor.reset_encoder_position()
 
-# Reset IMU registers
-IMU.get_default_imu().reset()
-
 # Turn off the on-board LED
 Board.get_default_board().led_off()
 


### PR DESCRIPTION
We were originally resetting the registers at program completion to prep for the next run, but that's completely unnecessary because it already resets them at the beginning of the program, which is much more intuitive.

This cuts out the potential calibration time from resetbot if the imu is never instantiated