### PR TITLE
Speed control bug fix, Straight and Turn retuned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/
 .git/
 docs/_build/
-
+.micropico
+.picowgo
 secrets.json

--- a/.picowgo
+++ b/.picowgo
@@ -1,3 +1,0 @@
-{
-    "info": "This file is just used to identify a project folder."
-}

--- a/Examples/drive_examples.py
+++ b/Examples/drive_examples.py
@@ -38,7 +38,7 @@ def circle():
 # Follow the perimeter of a square with variable sidelength
 def square(sidelength):
     for sides in range(4):
-        drivetrain.straight(sidelength, 80)
+        drivetrain.straight(sidelength, 0.8)
         drivetrain.turn(90)
     # Alternatively:
     # polygon(sidelength, 4)

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -155,7 +155,7 @@ class DifferentialDrive:
                 ki = 0.0125,
                 kd = 0.025,
                 min_output = 0.225,
-                max_output = 0.5,
+                max_output = max_effort,
                 max_integral = 35,
                 tolerance = 0.1,
                 tolerance_count = 3,

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -145,8 +145,8 @@ class DifferentialDrive:
             distance *= -1
 
         time_out = Timeout(timeout)
-        startingLeft = self.get_left_encoder_position()
-        startingRight = self.get_right_encoder_position()
+        starting_left = self.get_left_encoder_position()
+        starting_right = self.get_right_encoder_position()
 
 
         if main_controller is None:
@@ -154,11 +154,11 @@ class DifferentialDrive:
                 kp = 0.04,
                 ki = 0.0125,
                 kd = 0.025,
-                minOutput = 0.225,
-                maxOutput = 0.5,
-                maxIntegral = 35,
+                min_output = 0.225,
+                max_output = 0.5,
+                max_integral = 35,
                 tolerance = 0.1,
-                toleranceCount = 3,
+                tolerance_count = 3,
             )
 
         # Secondary controller to keep encoder values in sync
@@ -176,13 +176,13 @@ class DifferentialDrive:
         while True:
 
             # calculate the distance traveled
-            leftDelta = self.get_left_encoder_position() - startingLeft
-            rightDelta = self.get_right_encoder_position() - startingRight
-            distTraveled = (leftDelta + rightDelta) / 2
+            left_delta = self.get_left_encoder_position() - starting_left
+            right_delta = self.get_right_encoder_position() - starting_right
+            dist_traveled = (left_delta + right_delta) / 2
 
             # PID for distance
-            distanceError = distance - distTraveled
-            effort = main_controller.update(distanceError)
+            distance_error = distance - dist_traveled
+            effort = main_controller.update(distance_error)
             
             if main_controller.is_done() or time_out.is_done():
                 break
@@ -192,7 +192,7 @@ class DifferentialDrive:
                 # record current heading to maintain it
                 current_heading = self.imu.get_yaw()
             else:
-                current_heading = ((rightDelta-leftDelta)/2)*360/(self.track_width*math.pi)
+                current_heading = ((right_delta-left_delta)/2)*360/(self.track_width*math.pi)
 
             headingCorrection = secondary_controller.update(initial_heading - current_heading)
             
@@ -232,20 +232,20 @@ class DifferentialDrive:
             turn_degrees *= -1
 
         time_out = Timeout(timeout)
-        startingLeft = self.get_left_encoder_position()
-        startingRight = self.get_right_encoder_position()
+        starting_left = self.get_left_encoder_position()
+        starting_right = self.get_right_encoder_position()
 
         if main_controller is None:
             main_controller = PID(
                 kp = 0.02,
                 ki = 0.005,
                 kd = 0.012,
-                minOutput = 0.35,
-                maxOutput = max_effort,
-                maxDerivative = 0.5,
-                maxIntegral = 50,
+                min_output = 0.35,
+                max_output = max_effort,
+                max_derivative = 0.5,
+                max_integral = 50,
                 tolerance = 0.5,
-                toleranceCount = 2
+                tolerance_count = 2
             )
 
         # Secondary controller to keep encoder values in sync
@@ -260,25 +260,25 @@ class DifferentialDrive:
         while True:
             
             # calculate encoder correction to minimize drift
-            leftDelta = self.get_left_encoder_position() - startingLeft
-            rightDelta = self.get_right_encoder_position() - startingRight
-            encoderCorrection = secondary_controller.update(leftDelta + rightDelta)
+            left_delta = self.get_left_encoder_position() - starting_left
+            right_delta = self.get_right_encoder_position() - starting_right
+            encoder_correction = secondary_controller.update(left_delta + right_delta)
 
             if use_imu and (self.imu is not None):
                 # calculate turn error (in degrees) from the imu
-                turnError = turn_degrees - self.imu.get_yaw()
+                turn_error = turn_degrees - self.imu.get_yaw()
             else:
                 # calculate turn error (in degrees) from the encoder counts
-                turnError = turn_degrees - ((rightDelta-leftDelta)/2)*360/(self.track_width*math.pi)
+                turn_error = turn_degrees - ((right_delta-left_delta)/2)*360/(self.track_width*math.pi)
 
             # Pass the turn error to the main controller to get a turn speed
-            turnSpeed = main_controller.update(turnError)
+            turn_speed = main_controller.update(turn_error)
             
             # exit if timeout or tolerance reached
             if main_controller.is_done() or time_out.is_done():
                 break
 
-            self.set_speed(-turnSpeed - encoderCorrection, turnSpeed - encoderCorrection)
+            self.set_speed(-turn_speed - encoder_correction, turn_speed - encoder_correction)
 
             time.sleep(0.01)
 

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -277,7 +277,7 @@ class DifferentialDrive:
             if main_controller.is_done() or time_out.is_done():
                 break
 
-            self.set_speed(-turn_speed - encoder_correction, turn_speed - encoder_correction)
+            self.set_effort(-turn_speed - encoder_correction, turn_speed - encoder_correction)
 
             time.sleep(0.01)
 

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -235,18 +235,21 @@ class DifferentialDrive:
 
         if main_controller is None:
             main_controller = PID(
-                kp = .015,
-                kd = 0.0012,
-                minOutput = 0.25,
-                maxOutput = max_speed,
+                kp = 0.02,
+                ki = 0.005,
+                kd = 0.012,
+                minOutput = 0.35,
+                maxOutput = 0.5,
+                maxDerivative = 0.5,
+                maxIntegral = 50,
                 tolerance = 0.5,
-                toleranceCount = 3
+                toleranceCount = 2
             )
 
         # Secondary controller to keep encoder values in sync
         if secondary_controller is None:
             secondary_controller = PID(
-                kp = 0.0175,
+                kp = 1,
             )
  
         if use_imu and (self.imu is not None):

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -246,7 +246,7 @@ class DifferentialDrive:
         # Secondary controller to keep encoder values in sync
         if secondary_controller is None:
             secondary_controller = PID(
-                kp = 0.002,
+                kp = 0.0175,
             )
  
         if use_imu and (self.imu is not None):

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -151,20 +151,20 @@ class DifferentialDrive:
 
         if main_controller is None:
             main_controller = PID(
-                kp = 0.04,
-                ki = 0.0125,
-                kd = 0.025,
-                min_output = 0.225,
-                max_output = max_effort,
-                max_integral = 35,
-                tolerance = 0.1,
+                kp = 0.1,
+                ki = 0.04,
+                kd = 0.06,
+                min_output = 0.25,
+                max_output = 0.5,
+                max_integral = 10,
+                tolerance = 0.25,
                 tolerance_count = 3,
             )
 
         # Secondary controller to keep encoder values in sync
         if secondary_controller is None:
             secondary_controller = PID(
-                kp = 0.03, kd=0.003,
+                kp = 0.075, kd=0.005,
             )
 
         if self.imu is not None:
@@ -228,8 +228,8 @@ class DifferentialDrive:
         """
 
         if max_effort < 0:
-            max_effort *= -1
-            turn_degrees *= -1
+            max_effort = -max_effort
+            turn_degrees = -turn_degrees
 
         time_out = Timeout(timeout)
         starting_left = self.get_left_encoder_position()
@@ -238,20 +238,19 @@ class DifferentialDrive:
         if main_controller is None:
             main_controller = PID(
                 kp = 0.02,
-                ki = 0.005,
-                kd = 0.012,
+                ki = 0.001,
+                kd = 0.00165,
                 min_output = 0.35,
-                max_output = max_effort,
-                max_derivative = 0.5,
-                max_integral = 50,
-                tolerance = 0.5,
-                tolerance_count = 2
+                max_output = 0.5,
+                max_integral = 75,
+                tolerance = 1,
+                tolerance_count = 3
             )
 
         # Secondary controller to keep encoder values in sync
         if secondary_controller is None:
             secondary_controller = PID(
-                kp = 1,
+                kp = 1.0,
             )
  
         if use_imu and (self.imu is not None):

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -151,10 +151,12 @@ class DifferentialDrive:
 
         if main_controller is None:
             main_controller = PID(
-                kp = 0.075,
-                kd = 0.005,
-                minOutput = 0.25,
-                maxOutput = max_effort,
+                kp = 0.04,
+                ki = 0.0125,
+                kd = 0.025,
+                minOutput = 0.225,
+                maxOutput = 0.5,
+                maxIntegral = 35,
                 tolerance = 0.1,
                 toleranceCount = 3,
             )
@@ -162,7 +164,7 @@ class DifferentialDrive:
         # Secondary controller to keep encoder values in sync
         if secondary_controller is None:
             secondary_controller = PID(
-                kp = 0.025, kd=0.0025,
+                kp = 0.03, kd=0.003,
             )
 
         if self.imu is not None:
@@ -203,16 +205,16 @@ class DifferentialDrive:
         return not time_out.is_done()
 
 
-    def turn(self, turn_degrees: float, max_speed: float = 40, timeout: float = None, main_controller: Controller = None, secondary_controller: Controller = None, use_imu:bool = True) -> bool:
+    def turn(self, turn_degrees: float, max_effort: float = 40, timeout: float = None, main_controller: Controller = None, secondary_controller: Controller = None, use_imu:bool = True) -> bool:
         """
         Turn the robot some relative heading given in turnDegrees, and exit function when the robot has reached that heading.
-        Speed is bounded from -1 (turn counterclockwise the relative heading at full speed) to 1 (turn clockwise the relative heading at full speed)
+        effort is bounded from -1 (turn counterclockwise the relative heading at full speed) to 1 (turn clockwise the relative heading at full speed)
         Uses the IMU to determine the heading of the robot and P control for the motor controller.
 
         :param turnDegrees: The number of angle for the robot to turn (In Degrees)
         :type turnDegrees: float
-        :param max_speed: The max speed for each wheel of the robot to spin, in cm/s. Default is 40 cm/s.
-        :type max_speed: float
+        :param max_effort: The max speed for which the robot to travel (Bounded from -1 to 1)
+        :type max_effort: float
         :param timeout: The amount of time before the robot stops trying to turn and continues to the next step (In Seconds)
         :type timeout: float
         :param main_controller: The main controller, for handling the angle turned
@@ -225,8 +227,8 @@ class DifferentialDrive:
         :rtype: bool
         """
 
-        if max_speed < 0:
-            max_speed *= -1
+        if max_effort < 0:
+            max_effort *= -1
             turn_degrees *= -1
 
         time_out = Timeout(timeout)
@@ -239,7 +241,7 @@ class DifferentialDrive:
                 ki = 0.005,
                 kd = 0.012,
                 minOutput = 0.35,
-                maxOutput = 0.5,
+                maxOutput = max_effort,
                 maxDerivative = 0.5,
                 maxIntegral = 50,
                 tolerance = 0.5,

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -203,7 +203,7 @@ class DifferentialDrive:
         return not time_out.is_done()
 
 
-    def turn(self, turn_degrees: float, max_effort: float = 0.5, timeout: float = None, main_controller: Controller = None, secondary_controller: Controller = None, use_imu:bool = True) -> bool:
+    def turn(self, turn_degrees: float, max_speed: float = 40, timeout: float = None, main_controller: Controller = None, secondary_controller: Controller = None, use_imu:bool = True) -> bool:
         """
         Turn the robot some relative heading given in turnDegrees, and exit function when the robot has reached that heading.
         Speed is bounded from -1 (turn counterclockwise the relative heading at full speed) to 1 (turn clockwise the relative heading at full speed)
@@ -211,8 +211,8 @@ class DifferentialDrive:
 
         :param turnDegrees: The number of angle for the robot to turn (In Degrees)
         :type turnDegrees: float
-        :param max_effort: The max effort for which the robot to travel (Bounded from -1 to 1). Default is half effort forward.
-        :type max_effort: float
+        :param max_speed: The max speed for each wheel of the robot to spin, in cm/s. Default is 40 cm/s.
+        :type max_speed: float
         :param timeout: The amount of time before the robot stops trying to turn and continues to the next step (In Seconds)
         :type timeout: float
         :param main_controller: The main controller, for handling the angle turned
@@ -225,8 +225,8 @@ class DifferentialDrive:
         :rtype: bool
         """
 
-        if max_effort < 0:
-            max_effort *= -1
+        if max_speed < 0:
+            max_speed *= -1
             turn_degrees *= -1
 
         time_out = Timeout(timeout)
@@ -238,7 +238,7 @@ class DifferentialDrive:
                 kp = .015,
                 kd = 0.0012,
                 minOutput = 0.25,
-                maxOutput = max_effort,
+                maxOutput = max_speed,
                 tolerance = 0.5,
                 toleranceCount = 3
             )
@@ -273,7 +273,7 @@ class DifferentialDrive:
             if main_controller.is_done() or time_out.is_done():
                 break
 
-            self.set_effort(-turnSpeed - encoderCorrection, turnSpeed - encoderCorrection)
+            self.set_speed(-turnSpeed - encoderCorrection, turnSpeed - encoderCorrection)
 
             time.sleep(0.01)
 

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -205,7 +205,7 @@ class DifferentialDrive:
         return not time_out.is_done()
 
 
-    def turn(self, turn_degrees: float, max_effort: float = 40, timeout: float = None, main_controller: Controller = None, secondary_controller: Controller = None, use_imu:bool = True) -> bool:
+    def turn(self, turn_degrees: float, max_effort: float = 0.5, timeout: float = None, main_controller: Controller = None, secondary_controller: Controller = None, use_imu:bool = True) -> bool:
         """
         Turn the robot some relative heading given in turnDegrees, and exit function when the robot has reached that heading.
         effort is bounded from -1 (turn counterclockwise the relative heading at full speed) to 1 (turn clockwise the relative heading at full speed)

--- a/XRPLib/encoded_motor.py
+++ b/XRPLib/encoded_motor.py
@@ -115,15 +115,16 @@ class EncodedMotor:
     def set_speed(self, speed_rpm: float = None):
         """
         Sets target speed (in rpm) to be maintained passively
-        Call with no parameters to turn off speed control
+        Call with no parameters or 0 to turn off speed control
 
         :param target_speed_rpm: The target speed for the motor in rpm, or None
         :type target_speed_rpm: float, or None
         """
-        if speed_rpm is None:
+        if speed_rpm is None or speed_rpm == 0:
             self.target_speed = None
             self.set_effort(0)
             self.speed = 0
+            self.updateTimer.deinit()
             return
         # If the update timer is not running, start it at 50 Hz (20ms updates)
         self.updateTimer.init(period=20, callback=lambda t:self._update())

--- a/XRPLib/encoded_motor.py
+++ b/XRPLib/encoded_motor.py
@@ -131,6 +131,7 @@ class EncodedMotor:
         # Convert from rev per min to counts per 20ms (60 sec/min, 50 Hz)
         self.target_speed = speed_rpm*self._encoder.resolution/(60*50)
         self.speedController.clear_history()
+        self.prev_position = self.get_position_counts()
 
     def set_speed_controller(self, new_controller: Controller):
         """

--- a/XRPLib/pid.py
+++ b/XRPLib/pid.py
@@ -11,43 +11,45 @@ class PID(Controller):
                  kp = 1.0,
                  ki = 0.0,
                  kd = 0.0,
-                 minOutput = 0.0,
-                 maxOutput = 1.0,
-                 maxDerivative = None,
+                 min_output = 0.0,
+                 max_output = 1.0,
+                 max_derivative = None,
+                 max_integral = None,
                  tolerance = 0.1,
-                 toleranceCount = 1
+                 tolerance_count = 1
                  ):
         """
         :param kp: proportional gain
         :param ki: integral gain
         :param kd: derivative gain
-        :param minOutput: minimum output
-        :param maxOutput: maximum output
-        :param maxDerivative: maximum derivative (change per second)
+        :param min_output: minimum output
+        :param max_output: maximum output
+        :param max_derivative: maximum derivative (change per second)
+        :param max_integral: maximum integral windup allowed (will cap integral at this value)
         :param tolerance: tolerance for exit condition
-        :param numTimesInTolerance: number of times in tolerance for exit condition
+        :param tolerance_count: number of times the error needs to be within tolerance for is_done to return True
         """
         self.kp = kp
         self.ki = ki
         self.kd = kd
-        self.minOutput = minOutput
-        self.maxOutput = maxOutput
-        self.maxDerivative = maxDerivative
+        self.min_output = min_output
+        self.max_output = max_output
+        self.max_derivative = max_derivative
+        self.max_integral = max_integral
         self.tolerance = tolerance
-        self.toleranceCount = toleranceCount
+        self.tolerance_count = tolerance_count
 
-        self.prevError = 0
-        self.prevIntegral = 0
-        self.prevOutput = 0
+        self.prev_error = 0
+        self.prev_integral = 0
+        self.prev_output = 0
 
-        self.startTime = None
-        self.prevTime = None
+        self.start_time = None
+        self.prev_time = None
 
         # number of actual times in tolerance
         self.times = 0
 
     def _handle_exit_condition(self, error: float):
-
         if abs(error) < self.tolerance:
             # if error is within tolerance, increment times in tolerance
             self.times += 1
@@ -65,43 +67,47 @@ class PID(Controller):
         :return: The system output from the controller, to be used as an effort value or for any other purpose
         :rtype: float
         """
-        currentTime = time.ticks_ms()
-        if self.prevTime is None:
+        current_time = time.ticks_ms()
+        if self.prev_time is None:
             # First update after instantiation
-            self.startTime = currentTime
+            self.start_time = current_time
             timestep = 0.01
         else:
             # get time delta in seconds
-            timestep = time.ticks_diff(currentTime, self.prevTime) / 1000
-        self.prevTime = currentTime # cache time for next update
+            timestep = time.ticks_diff(current_time, self.prev_time) / 1000
+        self.prev_time = current_time # cache time for next update
 
         self._handle_exit_condition(error)
 
-        integral = self.prevIntegral + error * timestep
-        derivative = (error - self.prevError) / timestep
+        integral = self.prev_integral + error * timestep
+        
+        if self.max_integral is not None:
+            integral = max(-self.max_integral, min(self.max_integral, integral))
+
+        derivative = (error - self.prev_error) / timestep
 
         # derive output
         output = self.kp * error + self.ki * integral + self.kd * derivative
-        self.prevError = error
-        self.prevIntegral = integral
+        self.prev_error = error
+        self.prev_integral = integral
 
         # Bound output by minimum
         if output > 0:
-            output = max(self.minOutput, output)
+            output = max(self.min_output, output)
         else:
-            output = min(-self.minOutput, output)
+            output = min(-self.min_output, output)
         
         # Bound output by maximum
-        output = max(-self.maxOutput, min(self.maxOutput, output))
+        output = max(-self.max_output, min(self.max_output, output))
 
         # Bound output by maximum acceleration
-        if self.maxDerivative is not None:
-            lowerBound = self.prevOutput - self.maxDerivative * timestep
-            upperBound = self.prevOutput + self.maxDerivative * timestep
-            output = max(lowerBound, min(upperBound, output))
+        if self.max_derivative is not None:
+            lower_bound = self.prev_output - self.max_derivative * timestep
+            upper_bound = self.prev_output + self.max_derivative * timestep
+            output = max(lower_bound, min(upper_bound, output))
 
         # cache output for next update
-        self.prevOutput = output
+        self.prev_output = output
 
         return output
     
@@ -110,12 +116,11 @@ class PID(Controller):
         :return: if error is within tolerance for numTimesInTolerance consecutive times, or timed out
         :rtype: bool
         """
-
-        return self.times >= self.toleranceCount
+        return self.times >= self.tolerance_count
     
     def clear_history(self):
-        self.prevError = 0
-        self.prevIntegral = 0
-        self.prevOutput = 0
+        self.prev_error = 0
+        self.prev_integral = 0
+        self.prev_output = 0
+        self.prev_time = None
         self.times = 0
-        self.prevTime = None

--- a/XRPLib/pid.py
+++ b/XRPLib/pid.py
@@ -118,3 +118,4 @@ class PID(Controller):
         self.prevIntegral = 0
         self.prevOutput = 0
         self.times = 0
+        self.prevTime = None

--- a/XRPLib/pid.py
+++ b/XRPLib/pid.py
@@ -87,7 +87,7 @@ class PID(Controller):
         derivative = (error - self.prev_error) / timestep
 
         # derive output
-        output = self.kp * error + self.ki * integral + self.kd * derivative
+        output = self.kp * error + self.ki * integral - self.kd * derivative
         self.prev_error = error
         self.prev_integral = integral
 

--- a/XRPLib/resetbot.py
+++ b/XRPLib/resetbot.py
@@ -11,7 +11,7 @@ Run this file after interrupting a program to stop the robot by running "import 
 # using the EncodedMotor since the default drivetrain uses the IMU and takes 3 seconds to init
 for i in range(4):
     motor = EncodedMotor.get_default_encoded_motor(i+1)
-    motor.set_effort(0)
+    motor.set_speed(0)
     motor.reset_encoder_position()
 
 # Turn off the on-board LED


### PR DESCRIPTION
- Fixes speed control by properly resetting the previous time in the clear_history method
- Added a max_integral term to the PID class, used in default controllers for straight and turn
- Renamed symbols in the PID class to be properly in snake_case
- Re-tuned straight and turn to include an Integral term, removing cases where the robot may get stuck trying to complete a command