### PR TITLE
Fixed divide by zero edge case in Arcade Drive

### DIFF
--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -95,10 +95,11 @@ class DifferentialDrive:
         """
         if straight == 0 and turn == 0:
             self.set_effort(0, 0)
-        scale = max(abs(straight), abs(turn))/(abs(straight) + abs(turn))
-        left_speed = (straight - turn)*scale
-        right_speed = (straight + turn)*scale
-        self.set_effort(left_speed, right_speed)
+        else:
+            scale = max(abs(straight), abs(turn))/(abs(straight) + abs(turn))
+            left_speed = (straight - turn)*scale
+            right_speed = (straight + turn)*scale
+            self.set_effort(left_speed, right_speed)
 
     def reset_encoder_position(self) -> None:
         """

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -93,6 +93,8 @@ class DifferentialDrive:
         :param turn: The modifier effort (Bounded from -1 to 1) used to skew robot left (positive) or right (negative).
         :type turn: float
         """
+        if straight == 0 and turn == 0:
+            self.set_effort(0, 0)
         scale = max(abs(straight), abs(turn))/(abs(straight) + abs(turn))
         left_speed = (straight - turn)*scale
         right_speed = (straight + turn)*scale


### PR DESCRIPTION
Very simple bug, now just stops both motors when passed in `drivetrain.arcade(0,0)`