### PR TITLE
Motor fixes for v1.21

### DIFF
--- a/XRPLib/motor.py
+++ b/XRPLib/motor.py
@@ -8,6 +8,7 @@ class Motor:
     def __init__(self, direction_pin: int, speed_pin: int, flip_dir:bool=False):
         self._dirPin = Pin(direction_pin, Pin.OUT)
         self._speedPin = PWM(Pin(speed_pin, Pin.OUT))
+        self._speedPin.freq(50)
         self.flip_dir = flip_dir
         self._MAX_PWM = 65534 # Motor holds when actually at full power
 


### PR DESCRIPTION
Fixes issue where motor set_effort fails on the new micropython firmware. Now properly sets the PWM frequency instead of relying on the default