### PR TITLE
fix(XRPLib): update pin names to match latest MicroPython machine config

### DIFF
--- a/XRPLib/board.py
+++ b/XRPLib/board.py
@@ -16,8 +16,8 @@ class Board:
             cls._DEFAULT_BOARD_INSTANCE = cls()
         return cls._DEFAULT_BOARD_INSTANCE
 
-    def __init__(self, vin_pin="BOARD_VIN_MEASURE", button_pin="BOARD_USER_BUTTON", 
-                 rgb_led_pin = "BOARD_NEOPIXEL", led_pin = "LED"):
+    def __init__(self, vin_pin="VIN_MEAS", button_pin="USER_BUTTON", 
+                 rgb_led_pin = "RGB_LED", led_pin = "LED"):
         """
         Implements for extra features on the XRP board. Handles the on/off switch, button, and LED.
 

--- a/XRPLib/encoded_motor.py
+++ b/XRPLib/encoded_motor.py
@@ -33,29 +33,29 @@ class EncodedMotor:
         if index == 1:
             if cls._DEFAULT_LEFT_MOTOR_INSTANCE is None:
                 cls._DEFAULT_LEFT_MOTOR_INSTANCE = cls(
-                    MotorImplementation("MOTOR_L_IN_1", "MOTOR_L_IN_2", flip_dir=True),
-                    Encoder(0, "MOTOR_L_ENCODER_A", "MOTOR_L_ENCODER_B")
+                    MotorImplementation("MOTOR_L_IN1", "MOTOR_L_IN2", flip_dir=True),
+                    Encoder(0, "ENCODER_LA", "ENCODER_LB")
                 )
             motor = cls._DEFAULT_LEFT_MOTOR_INSTANCE
         elif index == 2:
             if cls._DEFAULT_RIGHT_MOTOR_INSTANCE is None:
                 cls._DEFAULT_RIGHT_MOTOR_INSTANCE = cls(
-                    MotorImplementation("MOTOR_R_IN_1", "MOTOR_R_IN_2"),
-                    Encoder(1, "MOTOR_R_ENCODER_A", "MOTOR_R_ENCODER_B")
+                    MotorImplementation("MOTOR_R_IN1", "MOTOR_R_IN2"),
+                    Encoder(1, "ENCODER_RA", "ENCODER_RB")
                 )
             motor = cls._DEFAULT_RIGHT_MOTOR_INSTANCE
         elif index == 3:
             if cls._DEFAULT_MOTOR_THREE_INSTANCE is None:
                 cls._DEFAULT_MOTOR_THREE_INSTANCE = cls(
-                    MotorImplementation("MOTOR_3_IN_1", "MOTOR_3_IN_2", flip_dir=True),
-                    Encoder(2, "MOTOR_3_ENCODER_A", "MOTOR_3_ENCODER_B")
+                    MotorImplementation("MOTOR_3_IN1", "MOTOR_3_IN2", flip_dir=True),
+                    Encoder(2, "ENCODER_3A", "ENCODER_3B")
                 )
             motor = cls._DEFAULT_MOTOR_THREE_INSTANCE
         elif index == 4:
             if cls._DEFAULT_MOTOR_FOUR_INSTANCE is None:
                 cls._DEFAULT_MOTOR_FOUR_INSTANCE = cls(
-                    MotorImplementation("MOTOR_4_IN_1", "MOTOR_4_IN_2"),
-                    Encoder(3, "MOTOR_4_ENCODER_A", "MOTOR_4_ENCODER_B")
+                    MotorImplementation("MOTOR_4_IN1", "MOTOR_4_IN2"),
+                    Encoder(3, "ENCODER_4A", "ENCODER_4B")
                 )
             motor = cls._DEFAULT_MOTOR_FOUR_INSTANCE
         else:

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -28,7 +28,7 @@ class IMU():
             cls._DEFAULT_IMU_INSTANCE.calibrate()
         return cls._DEFAULT_IMU_INSTANCE
 
-    def __init__(self, scl_pin: int|str = "I2C_SCL_1", sda_pin: int|str = "I2C_SDA_1", addr=LSM_ADDR_PRIMARY):
+    def __init__(self, scl_pin: int|str = "SCL1", sda_pin: int|str = "SDA1", addr=LSM_ADDR_PRIMARY):
         # I2C values
         self.i2c = I2C(id=1, scl=Pin(scl_pin), sda=Pin(sda_pin), freq=400000)
         self.addr = addr

--- a/XRPLib/rangefinder.py
+++ b/XRPLib/rangefinder.py
@@ -14,7 +14,7 @@ class Rangefinder:
             cls._DEFAULT_RANGEFINDER_INSTANCE = cls()
         return cls._DEFAULT_RANGEFINDER_INSTANCE
 
-    def __init__(self, trigger_pin: int|str = "RANGE_TRIGGER", echo_pin: int|str = "RANGE_ECHO", timeout_us:int=500*2*30):
+    def __init__(self, trigger_pin: int|str = "DIST_TRIG", echo_pin: int|str = "DIST_ECHO", timeout_us:int=500*2*30):
         """
         A basic class for using the HC-SR04 Ultrasonic Rangefinder.
         The sensor range is between 2cm and 4m.


### PR DESCRIPTION
Read about the issue I ran into here: https://xrp.discourse.group/t/micropython-error-during-installation-verification/652

This PR resolves the above issue by updating the pin names to match what is seen on the `Pin.board` interface in the MicroPython REPL. I'm not sure when this changed or if this is the correct place to make this change, so feel free to close this if there is a better way to fix the issue. 