### PR TITLE
Timeout was not working with a value of None after moving to the MS ticks

### DIFF
--- a/XRPLib/timeout.py
+++ b/XRPLib/timeout.py
@@ -8,7 +8,10 @@ class Timeout:
         :param timeout: The timeout, in seconds
         :type timeout: float
         """
-        self.timeout = timeout*1000
+        self.timeout = timeout
+        if self.timeout != None:
+            self.timeout = timeout*1000
+        
         self.start_time = time.ticks_ms()
     
     def is_done(self):


### PR DESCRIPTION
Fixed so None is handled which means don't set a timeout.