### PR TITLE
Change the rangefinder class to be non-blocking

### DIFF
--- a/XRPLib/rangefinder.py
+++ b/XRPLib/rangefinder.py
@@ -4,6 +4,9 @@ from machine import Pin, Timer
 class Rangefinder:
 
     _DEFAULT_RANGEFINDER_INSTANCE = None
+    _instances = []
+    _timer = None
+    _current_index = 0
 
     @classmethod
     def get_default_rangefinder(cls):
@@ -14,12 +17,36 @@ class Rangefinder:
             cls._DEFAULT_RANGEFINDER_INSTANCE = cls()
         return cls._DEFAULT_RANGEFINDER_INSTANCE
 
+    @classmethod
+    def _start_shared_timer(cls):
+        """
+        Start the shared timer if it isn't already running.
+        One timer cycles through all rangefinder instances to prevent acoustic crosstalk.
+        """
+        if cls._timer is None:
+            cls._timer = Timer(-1)
+            cls._timer.init(mode=Timer.PERIODIC, period=60, callback=cls._timer_callback)
+
+    @classmethod
+    def _timer_callback(cls, _t):
+        """
+        Shared timer callback that triggers one rangefinder per tick,
+        cycling through all instances in round-robin order.
+        """
+        if not cls._instances:
+            return
+        instance = cls._instances[cls._current_index]
+        instance._do_ping()
+        cls._current_index = (cls._current_index + 1) % len(cls._instances)
+
     def __init__(self, trigger_pin: int|str = "RANGE_TRIGGER", echo_pin: int|str = "RANGE_ECHO", timeout_us:int=500*2*30):
         """
         A non-blocking class for using the HC-SR04 Ultrasonic Rangefinder.
         The sensor range is between 2cm and 4m.
-        Measurements are taken continuously in the background using a timer
+        Measurements are taken continuously in the background using a shared timer
         and pin IRQ, so distance() returns immediately with the most recent value.
+        When multiple rangefinders exist, they are pinged sequentially to prevent
+        acoustic crosstalk.
         Timeouts will return a MAX_VALUE (65535) instead of raising an exception.
 
         :param trigger_pin: The number of the pin on the microcontroller that's connected to the ``Trig`` pin on the HC-SR04.
@@ -38,29 +65,40 @@ class Rangefinder:
         # Init echo pin (in)
         self.echo = Pin(echo_pin, mode=Pin.IN, pull=None)
 
+        # Cache time functions as instance attributes for use in hard IRQ context,
+        # where global module lookups are not allowed
+        self._ticks_us = time.ticks_us
+        self._ticks_diff = time.ticks_diff
+
         self.cms = self.MAX_VALUE
         self._echo_start = 0
         self._waiting_for_echo = False
         self._trigger_time = 0
         self._first_reading_done = False
 
+        # Pre-bind methods as instance attributes so the shared timer callback
+        # can call them without creating bound method objects (which would
+        # allocate memory in hard IRQ context)
+        self._do_ping = self._trigger_ping
+        self._do_echo = self._echo_handler
+
         # Register echo pin IRQ for both rising and falling edges
-        self.echo.irq(trigger=Pin.IRQ_RISING | Pin.IRQ_FALLING, handler=self._echo_handler)
+        self.echo.irq(trigger=Pin.IRQ_RISING | Pin.IRQ_FALLING, handler=self._do_echo)
 
-        # Start a virtual timer to periodically send trigger pulses
-        # 60ms period matches the HC-SR04 recommended minimum cycle time
-        self._timer = Timer(-1)
-        self._timer.init(mode=Timer.PERIODIC, period=60, callback=self._trigger_ping)
+        # Register this instance and start the shared timer
+        Rangefinder._instances.append(self)
+        Rangefinder._start_shared_timer()
 
-    def _trigger_ping(self, t):
+    def _trigger_ping(self):
         """
-        Timer callback that sends a trigger pulse to the HC-SR04.
+        Send a trigger pulse to the HC-SR04.
+        Called by the shared timer callback.
         Only ~15us of work per call (negligible blocking).
         Also detects timeouts from previous measurements.
         """
         if self._waiting_for_echo:
             # Check if previous measurement timed out
-            if time.ticks_diff(time.ticks_us(), self._trigger_time) > self.timeout_us:
+            if self._ticks_diff(self._ticks_us(), self._trigger_time) > self.timeout_us:
                 self.cms = self.MAX_VALUE
                 self._waiting_for_echo = False
                 self._first_reading_done = True
@@ -74,7 +112,7 @@ class Rangefinder:
         self._trigger.value(1)
         self._delay_us(10)
         self._trigger.value(0)
-        self._trigger_time = time.ticks_us()
+        self._trigger_time = self._ticks_us()
         self._waiting_for_echo = True
 
     def _echo_handler(self, pin):
@@ -85,11 +123,11 @@ class Rangefinder:
         """
         if pin.value() == 1:
             # Rising edge - echo pulse started
-            self._echo_start = time.ticks_us()
+            self._echo_start = self._ticks_us()
         else:
             # Falling edge - echo pulse ended
             if self._waiting_for_echo:
-                pulse_time = time.ticks_diff(time.ticks_us(), self._echo_start)
+                pulse_time = self._ticks_diff(self._ticks_us(), self._echo_start)
                 if pulse_time > 0:
                     # Sound speed 343.2 m/s = 0.034320 cm/us = 1cm per 29.1us
                     # Divide by 2 because pulse travels to target and back
@@ -114,6 +152,6 @@ class Rangefinder:
         Custom implementation of time.sleep_us(), used to get around the bug in MicroPython where time.sleep_us()
         doesn't work properly and causes the IDE to hang when uploading the code
         """
-        start = time.ticks_us()
-        while time.ticks_diff(time.ticks_us(), start) < delay:
+        start = self._ticks_us()
+        while self._ticks_diff(self._ticks_us(), start) < delay:
             pass

--- a/XRPLib/rangefinder.py
+++ b/XRPLib/rangefinder.py
@@ -50,7 +50,7 @@ class Rangefinder:
         # Start a virtual timer to periodically send trigger pulses
         # 60ms period matches the HC-SR04 recommended minimum cycle time
         self._timer = Timer(-1)
-        self._timer.init(period=60, callback=self._trigger_ping)
+        self._timer.init(mode=Timer.PERIODIC, period=60, callback=self._trigger_ping)
 
     def _trigger_ping(self, t):
         """


### PR DESCRIPTION
## Summary
- Refactors the Rangefinder class to use a timer and pin IRQ for non-blocking distance measurements
- Measurements are taken continuously in the background (60ms cycle), so distance() returns immediately with the most recent value
- Timeouts are detected without blocking, returning MAX_VALUE (65535) instead of raising exceptions

## Test plan
- [ ] Verify distance() returns valid measurements for objects within 2cm-4m range
- [ ] Verify distance() returns MAX_VALUE when no object is in range
- [ ] Verify the first call to distance() blocks until an initial reading is available
- [ ] Verify subsequent calls return immediately without blocking
- [ ] Test that the timer-based approach does not interfere with other XRP subsystems