### PR TITLE
NanoXRP: Battery voltage function, resetbot improvements, fixed package.json, fixed wheel_diam/wheel_track

### DIFF
--- a/XRPLib/board.py
+++ b/XRPLib/board.py
@@ -46,7 +46,11 @@ class Board:
         :return: Returns true if the batteries are connected and powering the motors, false otherwise
         :rytpe: bool
         """
-        return self.on_switch.read_u16() > 20000
+        if "NanoXRP" in sys.implementation._machine:
+            return True
+        
+        threshold_voltage = 4.272
+        return self.get_battery_voltage() > threshold_voltage
 
     def is_button_pressed(self) -> bool:
         """
@@ -125,3 +129,27 @@ class Board:
             self.rgb_led.write()
         else:
             raise NotImplementedError("Board.set_rgb_led not implemented for the XRP Beta")
+
+    def get_battery_voltage(self, vin_pin="BOARD_VIN_MEASURE") -> float:
+        """
+        Returns the current battery voltage in volts.
+
+        :param vin_pin: The pin the on/off switch is connected to
+        :type vin_pin: int
+        :return: Battery voltage in volts
+        :rtype: float
+        """
+
+        if "NanoXRP" in sys.implementation._machine:
+            # VIN pin on NanoXRP is also used for RM2.
+            self.on_switch = ADC(Pin(vin_pin))
+
+            battery_voltage = self.on_switch.read_u16() * (4.09 / 26000.0)
+
+            Pin(vin_pin, Pin.OUT)
+        else:
+            # RP2040 ADC is 0-4095, MicroPython scales it to 0-65535.
+            # The voltage divider is calibrated to a 14V full-scale reading.
+            battery_voltage = self.on_switch.read_u16() / ((1024 * 64) / 14)
+
+        return battery_voltage

--- a/XRPLib/defaults.py
+++ b/XRPLib/defaults.py
@@ -10,7 +10,6 @@ from .servo import Servo
 from .webserver import Webserver
 from .buzzer import Buzzer
 from machine import Pin
-from sys import implementation
 
 """
 A simple file that constructs all of the default objects for the XRP robot
@@ -24,12 +23,7 @@ if hasattr(Pin.board, "MOTOR_4_IN_1"):
     motor_four = EncodedMotor.get_default_encoded_motor(index=4)
 
 imu = IMU.get_default_imu()
-
-if "NanoXRP" in implementation._machine:
-    drivetrain = DifferentialDrive(left_motor, right_motor, imu, wheel_diam=3.46, wheel_track=7.8)
-else:
-    drivetrain = DifferentialDrive.get_default_differential_drive()
-
+drivetrain = DifferentialDrive.get_default_differential_drive()
 rangefinder = Rangefinder.get_default_rangefinder()
 reflectance = Reflectance.get_default_reflectance()
 servo_one = Servo.get_default_servo(index=1)

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -27,7 +27,7 @@ class DifferentialDrive:
             
         return cls._DEFAULT_DIFFERENTIAL_DRIVE_INSTANCE
 
-    def __init__(self, left_motor: EncodedMotor, right_motor: EncodedMotor, imu: IMU = None, wheel_diam:float = 6.0, wheel_track:float = 15.5):
+    def __init__(self, left_motor: EncodedMotor, right_motor: EncodedMotor, imu: IMU = None, wheel_diam:float = 0.0, wheel_track:float = 0.0):
         """
         A Differential Drive class designed for the XRP two-wheeled drive robot.
 
@@ -48,8 +48,18 @@ class DifferentialDrive:
         self.imu = imu
 
         self.brake_at_zero_power = False
-        self.wheel_diam = wheel_diam
-        self.track_width = wheel_track
+
+        if (wheel_diam == 0.0):
+            if "NanoXRP" in implementation._machine:
+                self.wheel_diam = 3.46
+            else:
+                self.wheel_diam = 6.0
+
+        if (wheel_track == 0.0):
+            if "NanoXRP" in implementation._machine:
+                self.wheel_track = 7.8
+            else:
+                self.wheel_track = 15.5
 
         self.heading_pid = None
         self.current_heading = None

--- a/XRPLib/resetbot.py
+++ b/XRPLib/resetbot.py
@@ -78,6 +78,3 @@ if "XRPLib.servo" in sys.modules:
 
 if "XRPLib.webserver" in sys.modules:
     reset_webserver()
-
-if "NanoXRP" in sys.implementation._machine:
-    Pin("BOARD_VIN_MEASURE", Pin.OUT)

--- a/XRPLib/resetbot.py
+++ b/XRPLib/resetbot.py
@@ -70,7 +70,7 @@ if "XRPLib.encoded_motor" in sys.modules:
 if "XRPLib.board" in sys.modules:
     reset_led()
 
-if "XRPLib.buzzer" in sys.modules:
+if hasattr(Pin.board, "BOARD_BUZZER"):
     reset_buzzer()
 
 if "XRPLib.servo" in sys.modules:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "urls": [
       ["XRPLib/__init__.py", "github:Open-STEM/XRP_Micropython/XRPLib/__init__.py"],
       ["XRPLib/board.py", "github:Open-STEM/XRP_Micropython/XRPLib/board.py"],
+      ["XRPLib/buzzer.py", "github:Open-STEM/XRP_Micropython/XRPLib/buzzer.py"],
       ["XRPLib/controller.py", "github:Open-STEM/XRP_Micropython/XRPLib/controller.py"],
       ["XRPLib/defaults.py", "github:Open-STEM/XRP_Micropython/XRPLib/defaults.py"],
       ["XRPLib/differential_drive.py", "github:Open-STEM/XRP_Micropython/XRPLib/differential_drive.py"],
@@ -20,6 +21,7 @@
       ["XRPLib/timeout.py", "github:Open-STEM/XRP_Micropython/XRPLib/timeout.py"],
       ["XRPLib/webserver.py", "github:Open-STEM/XRP_Micropython/XRPLib/webserver.py"],
       ["XRPExamples/__init__.py", "github:Open-STEM/XRP_Micropython/XRPExamples/__init__.py"],
+      ["XRPExamples/buzzer_examples.py", "github:Open-STEM/XRP_Micropython/XRPExamples/buzzer_examples.py"],
       ["XRPExamples/drive_examples.py", "github:Open-STEM/XRP_Micropython/XRPExamples/drive_examples.py"],
       ["XRPExamples/gamepad_example.blocks", "github:Open-STEM/XRP_Micropython/XRPExamples/gamepad_example.blocks"],
       ["XRPExamples/installation_verification.py", "github:Open-STEM/XRP_Micropython/XRPExamples/installation_verification.py"],
@@ -30,5 +32,5 @@
     "deps": [
       ["github:pimoroni/phew", "latest"]
     ],
-    "version": "2.1.3"
+    "version": "2.1.4"
   }


### PR DESCRIPTION
Replace the raw ADC threshold in Board.is_on with a voltage-based check (threshold 4.272 V) and add get_battery_voltage to read and convert ADC values. get_battery_voltage handles NanoXRP and RP2040 scaling and briefly toggles the VIN pin when needed. Also remove manual VIN pin reconfiguration from resetbot.py.