### PR TITLE
Clear speed controller history when direction of speed changes

### DIFF
--- a/XRPLib/encoded_motor.py
+++ b/XRPLib/encoded_motor.py
@@ -88,6 +88,7 @@ class EncodedMotor:
         self.speedController = self.DEFAULT_SPEED_CONTROLLER
         self.prev_position = 0
         self.speed = 0
+        self.prev_speed = 0
         # Use a virtual timer so we can leave the hardware timers up for the user
         self.updateTimer = Timer(-1)
         # If the update timer is not running, start it at 50 Hz (20ms updates)
@@ -175,6 +176,12 @@ class EncodedMotor:
             self.set_effort(0)
             self.speedController.clear_history()
             return
+
+        if self.prev_speed * speed_rpm < 0:
+            self.speedController.clear_history()
+
+        self.prev_speed = speed_rpm
+
         # Convert from rev per min to counts per 20ms (60 sec/min, 50 Hz)
         self.target_speed = speed_rpm*self._encoder.resolution/(60*50)
 


### PR DESCRIPTION
Solves a problem similar to #83 in which the integral in the speed controller is preserved when switching directions.