### PR TITLE
Strip capital V from release tags

### DIFF
--- a/.github/workflows/publish-to-firmware.yml
+++ b/.github/workflows/publish-to-firmware.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "XRPLib version to publish (e.g. 2.2.4). Defaults to the release tag."
+        description: "XRPLib version to publish (e.g. 2026.07.1). Defaults to the release tag."
         required: false
 
 env:
@@ -35,8 +35,8 @@ jobs:
             echo "No version available from input or release tag." >&2
             exit 1
           fi
-          # Strip a leading 'v' (v2.2.4 -> 2.2.4)
-          VER="${RAW#v}"
+          # Strip a leading 'v' or 'V' (V2026.07.1 -> 2026.07.1)
+          VER="${RAW#[vV]}"
           echo "version=$VER" >> "$GITHUB_OUTPUT"
           echo "Publishing XRPLib $VER"
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ request there for a maintainer to review and merge. The bundle contains:
 - a generated `files.json`, and
 - a new entry in `boards/XRPLib/index.json`.
 
-The version is taken from the release tag with any leading `v` stripped
-(`v2.2.4` → `2.2.4`), and becomes the directory name and the `xrplib-<version>` id.
+The version is taken from the release tag with any leading `v` or `V` stripped
+(`V2026.07.1` → `2026.07.1`), and becomes the directory name and the `xrplib-<version>` id.
 
 The library version number has been changed to YY.MM.N - ex. 26.07.1 is the first version released in July 2026.
 


### PR DESCRIPTION
The V2026.07.1 tag kept its V, so the last run tried to publish `boards/XRPLib/V2026.07.1` with id `xrplib-V2026.07.1`. Matches `[vV]` now.