### PR TITLE
Refactor arcade heading hold, reverse steering

### DIFF
--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -80,8 +80,8 @@ class DifferentialDrive:
 
         self.heading_pid = None
         self.current_heading = None
-        self.reset_heading = True
-        self.turning = False
+        # True while arcade() is holding a captured heading during straight driving.
+        self._holding_heading = False
 
         if self.imu:
             self.heading_pid = PID( kp = 0.075, kd=0.001, )
@@ -159,37 +159,31 @@ class DifferentialDrive:
         """
         if straight == 0 and turn == 0:
             self.set_effort(0, 0)
-        else:
-            scale = max(abs(straight), abs(turn))/(abs(straight) + abs(turn))
-            left_speed = (straight - turn)*scale
-            right_speed = (straight + turn)*scale
+            return
 
-            if not self.heading_pid:
-                # if not using IMU assist to maintain heading, just pass down the left and right motor
-                # speeds to control movement
-                self.set_effort(left_speed, right_speed)
-            else:
-                # else if IMU assist is enabled, then use the IMU with PID to
-                # maintain a constant heading while driving.
-                if turn == 0:
-                    # straight drive requested, then maintain the current heading
-                    if self.turning:
-                        # if previously turning, then clear the turn indicator and reset the course heading
-                        self.reset_heading = True
-                        self.turning = False
+        # Mix straight and turn, then scale so the faster wheel's magnitude equals the larger
+        # input. This keeps the straight-to-turn ratio while preventing the sum from clipping.
+        scale = max(abs(straight), abs(turn)) / (abs(straight) + abs(turn))
+        left = (straight - turn) * scale
+        right = (straight + turn) * scale
 
-                    if self.reset_heading:
-                        self.reset_heading = False
-                        self.current_heading = self.imu.get_yaw()
+        if not self.heading_pid:
+            # No IMU assist: drive the mixed efforts directly.
+            self.set_effort(left, right)
+            return
 
-                    # use the PID to set the heading correction based on the current heading
-                    heading_correction = self.heading_pid.update(self.current_heading - self.imu.get_yaw())
+        if turn != 0:
+            # Turning: drive directly, and force the next straight frame to recapture heading.
+            self._holding_heading = False
+            self.set_effort(left, right)
+            return
 
-                    self.set_effort(left_speed - heading_correction, right_speed + heading_correction)
-                else:
-                    # set the turning indicator and apply the left and right speeds
-                    self.turning = True
-                    self.set_effort(left_speed, right_speed)
+        # Straight with IMU assist: capture the heading once on entry, then hold it with PID.
+        if not self._holding_heading:
+            self.current_heading = self.imu.get_yaw()
+            self._holding_heading = True
+        correction = self.heading_pid.update(self.current_heading - self.imu.get_yaw())
+        self.set_effort(left - correction, right + correction)
 
     def reset_encoder_position(self) -> None:
         """

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -158,6 +158,7 @@ class DifferentialDrive:
         :type turn: float
         """
         if straight == 0 and turn == 0:
+            self._holding_heading = False
             self.set_effort(0, 0)
             return
 

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -84,7 +84,10 @@ class DifferentialDrive:
         self._holding_heading = False
 
         if self.imu:
-            self.heading_pid = PID(kp=0.075, kd=0.001)
+            if "NanoXRP" in implementation._machine:
+                self.heading_pid = PID(kp=0.014, kd=0.001)
+            else:
+                self.heading_pid = PID(kp=0.064, kd=0.0045)
 
     def update_voltage_compensation(self) -> float:
         """

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -161,13 +161,6 @@ class DifferentialDrive:
         :type turn: float
 
         """
-        _deadband = 0.1
-        # Ignore small resting inputs from joystick drift so the robot sits still near center.
-        if abs(straight) < _deadband:
-            straight = 0
-        if abs(turn) < _deadband:
-            turn = 0
-
         if straight == 0 and turn == 0:
             self._holding_heading = False
             self.set_effort(0, 0)

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -84,7 +84,7 @@ class DifferentialDrive:
         self._holding_heading = False
 
         if self.imu:
-            self.heading_pid = PID( kp = 0.075, kd=0.001, )
+            self.heading_pid = PID(kp=0.075, kd=0.001)
 
     def update_voltage_compensation(self) -> float:
         """
@@ -156,7 +156,15 @@ class DifferentialDrive:
         :type straight: float
         :param turn: The modifier effort (Bounded from -1 to 1) used to skew robot left (positive) or right (negative).
         :type turn: float
+
         """
+        _deadband = 0.1
+        # Ignore small resting inputs from joystick drift so the robot sits still near center.
+        if abs(straight) < _deadband:
+            straight = 0
+        if abs(turn) < _deadband:
+            turn = 0
+
         if straight == 0 and turn == 0:
             self._holding_heading = False
             self.set_effort(0, 0)
@@ -182,6 +190,7 @@ class DifferentialDrive:
         # Straight with IMU assist: capture the heading once on entry, then hold it with PID.
         if not self._holding_heading:
             self.current_heading = self.imu.get_yaw()
+            self.heading_pid.clear_history()
             self._holding_heading = True
         correction = self.heading_pid.update(self.current_heading - self.imu.get_yaw())
         self.set_effort(left - correction, right + correction)

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -173,6 +173,10 @@ class DifferentialDrive:
             self.set_effort(0, 0)
             return
 
+        # Flip the turn when reversing so the robot steers toward the stick either way.
+        if straight < 0:
+            turn = -turn
+
         # Mix straight and turn, then scale so the faster wheel's magnitude equals the larger
         # input. This keeps the straight-to-turn ratio while preventing the sum from clipping.
         scale = max(abs(straight), abs(turn)) / (abs(straight) + abs(turn))


### PR DESCRIPTION
## Summary

Cleans up `arcade()` and its IMU heading-hold, and fixes two teleop feel issues. Single file, `differential_drive.py`.

## Changes

- **Per-board heading gains.** The single `kp=0.075, kd=0.001` is replaced with tuned values: non-Nano `kp=0.064, kd=0.0045`, Nano `kp=0.014, kd=0.001`.

- **Reverse steering fix.** Pushing back-and-left used to curve the robot *right* (the turn kept the same rotation direction as forward). Turn is now flipped when reversing, so the robot steers toward the stick either way.

- **Collapsed the heading-hold state machine.** The two flags `turning` + `reset_heading` are replaced by one `_holding_heading`. Same behavior across every transition, far less to reason about. `arcade()` is flattened to early returns instead of 3-deep nesting, and the misnamed `left_speed`/`right_speed` (they're efforts) become `left`/`right`.

- **Stop forgets the held heading.** A neutral `(0, 0)` clears `_holding_heading`, so resuming straight recaptures the current heading rather than steering back toward the pre-stop one.

- **Fresh PID per straight segment.** `heading_pid.clear_history()` on entering straight prevents a prior turn's elapsed time from leaking into the controller's first derivative/integral step.
