### PR TITLE
Route per-board logic through Board.get_type()

### DIFF
--- a/XRPLib/board.py
+++ b/XRPLib/board.py
@@ -7,6 +7,26 @@ class Board:
 
     _DEFAULT_BOARD_INSTANCE = None
 
+    # Board identity. The one place a machine name is matched; everything else compares
+    # against these constants (see get_type).
+    XRP  = 0
+    BETA = 1
+    NANO = 2
+    _type = None
+
+    @classmethod
+    def get_type(cls) -> int:
+        """
+        Identify which XRP board this code is running on.
+
+        :return: One of Board.XRP, Board.BETA, or Board.NANO
+        :rtype: int
+        """
+        if cls._type is None:
+            machine = sys.implementation._machine
+            cls._type = cls.NANO if "NanoXRP" in machine else cls.BETA if "Beta" in machine else cls.XRP
+        return cls._type
+
     @classmethod
     def get_default_board(cls):
         """
@@ -47,9 +67,9 @@ class Board:
         :return: Returns true if the batteries are connected and powering the motors, false otherwise
         :rytpe: bool
         """
-        if "NanoXRP" in sys.implementation._machine:
+        if Board.get_type() == Board.NANO:
             return True
-        
+
         threshold_voltage = 4.272
         return self.get_battery_voltage() > threshold_voltage
 
@@ -141,7 +161,7 @@ class Board:
         :rtype: float
         """
 
-        if "NanoXRP" in sys.implementation._machine:
+        if Board.get_type() == Board.NANO:
             # VIN pin on NanoXRP is also used for RM2.
             self.on_switch = ADC(Pin(vin_pin))
 

--- a/XRPLib/dashboard.py
+++ b/XRPLib/dashboard.py
@@ -2,6 +2,7 @@ from .encoded_motor import EncodedMotor
 from .rangefinder import Rangefinder
 from .imu import IMU
 from .reflectance import Reflectance
+from .board import Board
 from .puppet import Puppet, VAR_TYPE_INT, VAR_TYPE_FLOAT, PERM_READ_ONLY
 
 from machine import Timer, ADC, Pin
@@ -82,7 +83,7 @@ class Dashboard:
         self.imu = IMU.get_default_imu()
         self.rangefinder = Rangefinder.get_default_rangefinder()
         self.reflectance = Reflectance.get_default_reflectance()
-        self.VoltageADC = ADC(Pin('BOARD_VIN_MEASURE'))
+        self.board = Board.get_default_board()
         #self.CurrLADC = ADC(Pin('ML_CUR'))
         #self.CurrRADC = ADC(Pin('MR_CUR'))
         #self.Curr3ADC = ADC(Pin('M3_CUR'))
@@ -188,7 +189,7 @@ class Dashboard:
         self._puppet.set_variable('$reflectance.right', self.reflectance.get_right())
         
         # Voltage
-        voltage = self.VoltageADC.read_u16() / (1024*64/14)
+        voltage = self.board.get_battery_voltage()
         self._puppet.set_variable('$voltage', voltage)
 
     def start(self, rate_hz=3):

--- a/XRPLib/differential_drive.py
+++ b/XRPLib/differential_drive.py
@@ -6,7 +6,6 @@ from .pid import PID
 from .timeout import Timeout
 import time
 import math
-from sys import implementation
 
 class DifferentialDrive:
 
@@ -38,9 +37,9 @@ class DifferentialDrive:
         :type rightMotor: EncodedMotor
         :param imu: The IMU of the robot. If None, the robot will not use the IMU for turning or maintaining heading.
         :type imu: IMU
-        :param wheelDiam: The diameter of the wheels in inches. Defaults to 6 cm.
+        :param wheelDiam: The diameter of the wheels in cm.
         :type wheelDiam: float
-        :param wheelTrack: The distance between the wheels in inches. Defaults to 15.5 cm.
+        :param wheelTrack: The distance between the wheels in cm.
         :type wheelTrack: float
         """
         
@@ -53,27 +52,18 @@ class DifferentialDrive:
         # Resolve hardware defaults when the caller leaves the arg at its 0.0 sentinel;
         # honor any explicit non-zero value that is passed in.
         if wheel_diam == 0.0:
-            if "NanoXRP" in implementation._machine:
-                self.wheel_diam = 3.46
-            else:
-                self.wheel_diam = 6.0
+            self.wheel_diam = 3.46 if Board.get_type() == Board.NANO else 6.0
         else:
             self.wheel_diam = wheel_diam
 
         if wheel_track == 0.0:
-            if "NanoXRP" in implementation._machine:
-                self.wheel_track = 7.8
-            else:
-                self.wheel_track = 15.5
+            self.wheel_track = 7.8 if Board.get_type() == Board.NANO else 15.5
         else:
             self.wheel_track = wheel_track
 
         # Effort is raw PWM duty, so torque scales with pack voltage. Gains are tuned against
         # nominal_voltage and voltage_scale corrects the duty for the pack actually installed.
-        if "NanoXRP" in implementation._machine:
-            self.nominal_voltage = 4.2
-        else:
-            self.nominal_voltage = 6.0
+        self.nominal_voltage = 4.2 if Board.get_type() == Board.NANO else 6.0
 
         self.voltage_scale = 1.0
         self.update_voltage_compensation()
@@ -220,9 +210,9 @@ class DifferentialDrive:
         Shared translation/rotation controller for straight() and turn().
         """
 
-        if "NanoXRP" in implementation._machine:
+        if Board.get_type() == Board.NANO:
             if min_effort is None:
-                min_effort = 0.10   
+                min_effort = 0.10
 
             if distance_controller is None:
                 distance_controller = PID(

--- a/XRPLib/encoded_motor.py
+++ b/XRPLib/encoded_motor.py
@@ -3,7 +3,7 @@ from .encoder import Encoder
 from machine import Timer, Pin
 from .controller import Controller
 from .pid import PID
-from sys import implementation
+from .board import Board
 
 class EncodedMotor:
 
@@ -25,10 +25,7 @@ class EncodedMotor:
         :type index: int
         """
         
-        if "Beta" in implementation._machine:
-            MotorImplementation = SinglePWMMotor
-        else:
-            MotorImplementation = DualPWMMotor
+        MotorImplementation = SinglePWMMotor if Board.get_type() == Board.BETA else DualPWMMotor
 
         if index == 1:
             if cls._DEFAULT_LEFT_MOTOR_INSTANCE is None:
@@ -70,7 +67,7 @@ class EncodedMotor:
         self.brake_at_zero = False
 
         self.target_speed = None
-        if "NanoXRP" in implementation._machine:
+        if Board.get_type() == Board.NANO:
             self.DEFAULT_SPEED_CONTROLLER = PID(
                 kp=0.015,
                 ki=0.06,

--- a/XRPLib/encoder.py
+++ b/XRPLib/encoder.py
@@ -3,11 +3,11 @@
 import machine
 import rp2
 import time
-from sys import implementation
+from .board import Board
 import re
 
 class Encoder:
-    if "NanoXRP" in implementation._machine:
+    if Board.get_type() == Board.NANO:
         _gear_ratio = (68/1)
         _counts_per_motor_shaft_revolution = 12
     else:

--- a/XRPLib/imu.py
+++ b/XRPLib/imu.py
@@ -11,7 +11,7 @@ except (TypeError, ModuleNotFoundError):
     # Import wrapped in a try/except so that autodoc generation can process properly
     pass
 from machine import I2C, Pin, Timer, disable_irq, enable_irq
-from sys import implementation
+from .board import Board
 import time, math
 
 class IMU():
@@ -30,7 +30,8 @@ class IMU():
         return cls._DEFAULT_IMU_INSTANCE
 
     def __init__(self, scl_pin: int|str = "I2C_SCL_1", sda_pin: int|str = "I2C_SDA_1", addr=LSM_ADDR_PRIMARY):
-        self._is_nanoxrp = "NanoXRP" in implementation._machine
+        # Cached once at construction so the hard-IRQ update handler never calls get_type().
+        self._is_nanoxrp = Board.get_type() == Board.NANO
 
         # I2C values
         self.i2c = I2C(id=1, scl=Pin(scl_pin), sda=Pin(sda_pin), freq=400000)

--- a/XRPLib/motor.py
+++ b/XRPLib/motor.py
@@ -1,5 +1,5 @@
 from machine import Pin, PWM
-from sys import implementation
+from .board import Board
 
 class SinglePWMMotor:
 
@@ -57,10 +57,7 @@ class DualPWMMotor:
 
     def __init__(self, in1_pwm_forward: int|str, in2_pwm_backward: int|str, flip_dir:bool=False):
 
-        if "NanoXRP" in implementation._machine:
-            self.flip_dir = not flip_dir
-        else:
-            self.flip_dir = flip_dir
+        self.flip_dir = (not flip_dir) if Board.get_type() == Board.NANO else flip_dir
 
         self._MAX_PWM = 65535 # Motor holds when actually at full power
 


### PR DESCRIPTION
## Summary

Replaces the scattered board-name string checks (`"NanoXRP" in implementation._machine`, `"Beta" in ...`) with a single detection point on `Board`, so per-board logic reads as data/identity comparisons instead of duplicated `_machine` matches — and adding a future board is a one-line change in `get_type()` rather than edits across the library.

## Changes

**`board.py` — the one detection point**
- Adds `Board.XRP` / `Board.BETA` / `Board.NANO` constants and a cached `Board.get_type()`. This is now the only place a machine name is matched.
- Its own `are_motors_powered` / `get_battery_voltage` checks use it.

**Call sites converted to `Board.get_type() == Board.<X>`**
- `differential_drive.py` — wheel diameter/track and `nominal_voltage` (ternaries); the `_move` tuning block keeps its `if` on the clean identity.
- `encoded_motor.py` — motor class (`SinglePWMMotor`/`DualPWMMotor`) as a ternary; the default speed controller keeps its `if/else` with one PID param per line.
- `motor.py` — `flip_dir` ternary.
- `imu.py` — the cached `_is_nanoxrp` init flag; the hard-IRQ update handler still reads that cached bool, so `get_type()` is never called from an interrupt.
- `encoder.py` — the `resolution` gear-ratio `if/else`.

Also includes a small related fix (separate commit): `dashboard.py` reads battery voltage via `Board.get_battery_voltage()` instead of a raw ADC, so it uses the per-board formula and, on the Nano, restores the shared VIN/RM2 pin after reading.
