### PR TITLE
No longer update PID derivative if timestep is 0

### DIFF
--- a/XRPLib/pid.py
+++ b/XRPLib/pid.py
@@ -41,6 +41,7 @@ class PID(Controller):
 
         self.prev_error = 0
         self.prev_integral = 0
+        self.prev_derivative = 0
         self.prev_output = 0
 
         self.start_time = None
@@ -84,10 +85,11 @@ class PID(Controller):
         if self.max_integral is not None:
             integral = max(-self.max_integral, min(self.max_integral, integral))
 
-        derivative = (error - self.prev_error) / timestep
+        if timestep != 0:
+            self.prev_derivative = (error - self.prev_error) / timestep
 
         # derive output
-        output = self.kp * error + self.ki * integral + self.kd * derivative
+        output = self.kp * error + self.ki * integral + self.kd * self.prev_derivative
         self.prev_error = error
         self.prev_integral = integral
 
@@ -110,7 +112,7 @@ class PID(Controller):
         self.prev_output = output
 
         if debug:
-            print(f"{output}: ({self.kp * error}, {self.ki * integral}, {self.kd * derivative})")
+            print(f"{output}: ({self.kp * error}, {self.ki * integral}, {self.kd * self.prev_derivative})")
 
         return output
     
@@ -124,6 +126,7 @@ class PID(Controller):
     def clear_history(self):
         self.prev_error = 0
         self.prev_integral = 0
+        self.prev_derivative = 0
         self.prev_output = 0
         self.prev_time = None
         self.times = 0


### PR DESCRIPTION
If a PID controller is updated multiple times in under a millisecond, the timestep becomes 0 and we get a divide by zero error when computing the derivative. We encountered this error initially with someone running the arcade function in a while loop with no delay. This PR fixes that by preventing the controller from updating its derivative if the timestep is zero, since if no time has passed the derivative shouldn't have changed.

To test I ran only the PID controller update function in a while True loop. The divide by zero error occurs with the old version of the controller and not with the new version.